### PR TITLE
Update APIs based on discussion

### DIFF
--- a/draft-ietf-asdf-nipc.mkd
+++ b/draft-ietf-asdf-nipc.mkd
@@ -879,6 +879,17 @@ This connection can be established as part of the same API call implicitly.
 If a connection is already active for this device, the existing connection willi
 be leveraged without modifying it.
 
+These APIs support multiple media types based on Content-Type and Accept
+headers to accommodate different data formats. 
+
+When using `application/octet-stream`, the raw binary data is sent 
+directly in the request/response body.
+When using `application/json`, the request and response bodies follow 
+the format shown in the examples above, with binary data encoded as 
+base64 in the "value" field. 
+For other content types, the data is transmitted according to the 
+specific format requirements of that media type.
+
 ### Write a value
 
 Method: `PUT /devices/{id}/properties/{propertyName}`
@@ -892,7 +903,7 @@ Parameters:
 
 Request Body:
 
- - value: the bytes to be written in base64 encoding
+the binary data to write to the property (using `application/octet-stream`)
 
 Response:
 
@@ -914,7 +925,13 @@ Parameters:
 
 Response:
 
-Example of a read property response:
+The response will be the binary data read from the property. 
+
+If the Accept header is set to `application/octet-stream`, the response body
+will contain the raw binary data.
+
+Example of a read property response if the Accept header is set to
+`application/json`:
 
 ~~~~~
 {
@@ -1933,40 +1950,26 @@ The sequence of operations for this are:
   - Read a property from the BLE device
 
     ~~~~~
-    GET /12345678-1234-5678-1234-56789abcdef4/property/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Fdevice_name
-    Accept: application/json
+    GET /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Fdevice_name
+    Accept: application/octet-stream
     Host: localhost
     
     HTTP/1.1 200 OK
-    content-type: application/json
+    content-type: application/octet-stream
     
-    {
-      "id": "12345678-1234-5678-1234-56789abcdef4",
-      "value": "dGVzdA==",
-      "sdfName": "https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/device_name"
-    }
+    ... (binary data)
     ~~~~~
  
   - Write to a property on the BLE device
 
     ~~~~~
-    PUT /12345678-1234-5678-1234-56789abcdef4/property/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Fdevice_name
-    Content-Type: application/json
-    Accept: application/json
+    PUT /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Fdevice_name
+    Content-Type: application/octet-stream
     Host: localhost
     
-    {
-      "value": "dGVzdA=="
-    }
+    ... (binary data)
     
-    HTTP/1.1 200 OK
-    content-type: application/json
-    
-    {
-      "id": "12345678-1234-5678-1234-56789abcdef4",
-      "value": "dGVzdA==",
-      "sdfName": "https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/device_name"
-    }
+    HTTP/1.1 204 No Content
     ~~~~~
 
 ## Enabling an Event
@@ -2017,174 +2020,35 @@ The sequence of operations for this are:
     content-type: application/json
 
     {
-      "id": "12345678-1234-5678-1234-56789abcdef4",
       "events": [
         "https://example.com/thermometer#/sdfThing/thermometer/sdfEvent/isPresent"
-      ]
+      ],
+      "mqttClient": {}
     }
     ~~~~~
 
   - Enable the advertisement event
 
     ~~~~
-    POST /12345678-1234-5678-1234-56789abcdef4/event/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfEvent%2FisPresent
-    Content-Type: application/json
-    Accept: application/json
+    POST /devices/12345678-1234-5678-1234-56789abcdef4/events/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfEvent%2FisPresent
     Host: localhost
     Content-Length: 0
     
-    HTTP/1.1 200 OK
-    content-type: application/json
-
-    {
-      "id": "12345678-1234-5678-1234-56789abcdef4",
-      "event": "https://example.com/thermometer#/sdfThing/thermometer/sdfEvent/isPresent"
-    }
+    HTTP/1.1 201 OK
+    Location: /devices/12345678-1234-5678-1234-56789abcdef4/events/87654321-4321-8765-4321-fedcba9876543
     ~~~~
 
-## Property read/write with explicit connection
-
-In this example, we will connect to a device explicitly and read and 
-write from a property.
-The sequence of operations for this are:  
-
-  - Onboard a device using the SCIM Interface (out of scope of this
-    memo)
-  - Connect to the device
+  - Check the status of the event
 
     ~~~~~
-    POST /devices/12345678-1234-5678-1234-56789abcdef4/manage/connection
-    Content-Type: application/json
-    Accept: application/json
-    Host: localhost
-    
-    {
-      "retries": 3,
-      "retryMultipleAPs": true,
-      "protocolMap": {
-        "ble": {
-          "services": [
-            {
-              "serviceID": "1800"
-            },
-            {
-              "serviceID": "1801"
-            }
-          ],
-          "cached": false,
-          "cacheIdlePurge": 3600,
-          "autoUpdate": true,
-          "bonding": "default"
-        }
-      }
-    }
-
-    HTTP/1.1 200 OK
-    content-type: application/json
-    
-    {
-      "id": "12345678-1234-5678-1234-56789abcdef4",
-      "protocolMap": {
-        "ble": [
-          {
-            "serviceID": "1800",
-            "characteristics": [
-              {
-                "characteristicID": "2A00",
-                "flags": [
-                  "read",
-                  "write"
-                ],
-                "descriptors": [
-                  {
-                    "descriptorID": "2901"
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    }
-    ~~~~~
-
-  - Read a property from the BLE device
-
-    ~~~~~
-    POST /extensions/12345678-1234-5678-1234-56789abcdef4/properties/read
-    Content-Type: application/json
-    Accept: application/json
-    Host: localhost
-
-    {
-      "protocolMap": {
-        "ble": {
-          "serviceID": "1800",
-          "characteristicID": "2A00"
-        }
-      }
-    }
-    
-    HTTP/1.1 200 OK
-    content-type: application/json
-    
-    {
-      "id": "12345678-1234-5678-1234-56789abcdef4",
-      "value": "dGVzdA==",
-      "protocolMap": {
-        "ble": {
-          "serviceID": "1800",
-          "characteristicID": "2A00"
-        }
-      }
-    }
-    ~~~~~
-
-  - Write to a property on the BLE device
-
-    ~~~~~
-    POST /extensions/12345678-1234-5678-1234-56789abcdef4/properties/write
-    Content-Type: application/json
-    Accept: application/json
-    Host: localhost
-    
-    {
-      "value": "dGVzdA==",
-      "protocolMap": {
-        "ble": {
-          "serviceID": "1800",
-          "characteristicID": "2A00"
-        }
-      }
-    }
-    
-    HTTP/1.1 200 OK
-    content-type: application/json
-    
-    {
-      "id": "12345678-1234-5678-1234-56789abcdef4",
-      "value": "dGVzdA==",
-      "protocolMap": {
-        "ble": {
-          "serviceID": "1800",
-          "characteristicID": "2A00"
-        }
-      }
-    }
-    ~~~~~
-
-  - Disconnect from the device
-
-    ~~~~~
-    DELETE /devices/12345678-1234-5678-1234-56789abcdef4/manage/connection
-    Accept: application/json
+    GET /devices/12345678-1234-5678-1234-56789abcdef4/events/87654321-4321-8765-4321-fedcba9876543
     Host: localhost
     
     HTTP/1.1 200 OK
     content-type: application/json
     
     {
-      "id": "12345678-1234-5678-1234-56789abcdef4"
+      "event": "https://example.com/thermometer#/sdfThing/thermometer/sdfEvent/isPresent"
     }
     ~~~~~
 

--- a/draft-ietf-asdf-nipc.mkd
+++ b/draft-ietf-asdf-nipc.mkd
@@ -374,7 +374,7 @@ tear down the connection after the operation has completed. A NIPC Gateway
 should support explicit connection management as well. Explicit connection
 management can be used by an app that wants to perform multiple NIPC operations
 in a single connection. Explicit connection management can be performed by 
-calling the /{id}/action/connection action API. When after establishing an
+calling the /devices/{id}/manage/connection action API. When after establishing an
 explicit connection to a device, an application calls a NIPC Operation, the
 Gateway will leverage the exissting connection and will also not tear the
 connection down after the operation completes. The app will have to explicitly
@@ -532,20 +532,21 @@ provide the result of the completed operation in the HTTP response.
 The exception to the above are NIPC extensions, {{apiextensions}}. These contain 
 compound statements, and thus require the gateway to execute multiple
 NIPC operations. In this case the NIPC gateway will return HTTP status
-code 200 after receiving the request and verifying it is able to execute it.
+code 202 after receiving the request and verifying it is able to execute it.
 The client can then perform an HTTP GET of the extension API to get the
 execution status for the request. If a callback URL was address was defined in
 the request, the NIPC Gateway can optionally perform a callback with a
 response to the compound request after the compound statement completes.
 
-Every NIPC API response has a `X-Request-ID` header, which is a unique 
-identifier for the request. Each successful response will have a HTTP 
-status code of 200 OK. 
+Actions also follow an asynchronous pattern, returning HTTP status code 202
+when the action is accepted, along with a Location header pointing to the
+action instance for status tracking.
 
 A failure response will consist of a HTTP status code of 4xx or 5xx, and 
-will contain an error code in the `nipcStatus` field and a 
-human-readable `detail` field. The error codes and the 
-appropriate error codes are described in {{errorhandling}}.
+will follow the {{!RFC9457}} Problem Details format with `application/problem+json`
+media type. The response will contain a `type` field with a URI identifying
+the error type, and a human-readable `detail` field. The `type` field
+is a URI and is described in {{errorhandling}}.
 
 Failure response: 
 
@@ -553,19 +554,20 @@ Example of a failure response:
 
 ~~~~~
 {
+  "type": "https://www.iana.org/assignments/http-problem-types#nipc-invalid-id",
   "status": 400,
-  "nipcStatus": 1000,
-  "detail": "Generic error message"
+  "title": "Invalid Device ID",
+  "detail": "Device ID 12345678-1234-5678-1234-56789abcdef4 does not exist or is not a device"
 }
 ~~~~~
 {: #failure title="Example failure response"}
 
 where-
 
+  - "type" is a URI identifying the specific error type
   - "status" is the HTTP status code
-  - "nipcStatus" is error code that indicates the type of error, 
-   as described in {{errorcodes}}
-  - "detail" is a human-readable error message
+  - "title" is a brief, human-readable summary of the error type
+  - "detail" is a human-readable explanation specific to this occurrence
 
 # NIPC Registrations
 
@@ -594,9 +596,11 @@ Response:
 Example of a response:
 
 ~~~~~
-{
-  "sdfName": "https://example.com/heartrate#/sdfObject/healthsensor"
-}
+[
+  {
+    "sdfName": "https://example.com/heartrate#/sdfObject/healthsensor"
+  }
+]
 ~~~~~
 {:json #exregresp title="Example register sdf model response"}
 
@@ -604,7 +608,6 @@ where-
 
  - "sdfName" is the reference to the top-level sdfThing or sdfObject 
     in the SDF model
- - "id" is the id of the sdf model
 
 ### Get all sdf models
 
@@ -629,7 +632,6 @@ where-
 
  - "sdfName" is the reference to the top-level sdfThing or sdfObject 
     in the SDF model
- - "id" is the id of the sdf model
 
 ### Get an sdf model
 
@@ -673,7 +675,6 @@ where-
 
  - "sdfName" is the reference to the top-level sdfThing or sdfObject 
     in the SDF model
- - "id" is the id of the sdf model
 
 ### Update an sdf model
 
@@ -705,7 +706,6 @@ where-
 
  - "sdfName" is the reference to the top-level sdfThing or sdfObject 
     in the SDF model
- - "id" is the id of the sdf model
 
 ## Data application registration APIs
 
@@ -881,14 +881,14 @@ be leveraged without modifying it.
 
 ### Write a value
 
-Method: `POST /{id}/property/{property}`
+Method: `PUT /devices/{id}/properties/{propertyName}`
 
 Description: Writes a value to a property on a device
 
 Parameters: 
 
  - id: the id of the device
- - property: the property to write to
+ - propertyName: the property to write to
 
 Request Body:
 
@@ -896,36 +896,21 @@ Request Body:
 
 Response:
 
-Example of a write property response:
-
-~~~~~
-{
-  "id": "12345678-1234-5678-1234-56789abcdef4",
-  "property": "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/temperature",
-  "value": "dGVzdA=="
-}
-~~~~~
-{:json #exwrresp title="Example write property response"}
-
-where-
-
- - "id" is the id of the device
- - "property" is the property that was written to
- - "value" is the bytes that were written in base64 encoding
+HTTP status code 204 No Content is returned for successful writes.
 
 A failure will generate a standard failed response. Please refer to {{failure}}
 definition of failed response.
 
 ### Read a value
 
-Method: `GET /{id}/property/{property}`
+Method: `GET /devices/{id}/properties/{propertyName}`
 
 Description: Reads a value from a property on a device
 
 Parameters: 
 
  - id: the id of the device
- - property: the property to read from
+ - propertyName: the property to read from
 
 Response:
 
@@ -933,8 +918,6 @@ Example of a read property response:
 
 ~~~~~
 {
-  "id": "12345678-1234-5678-1234-56789abcdef4",
-  "property": "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/temperature",
   "value": "dGVzdA=="
 }
 ~~~~~
@@ -942,8 +925,6 @@ Example of a read property response:
 
 where-
 
- - "id" is the id of the device
- - "property" is the property that was read from
  - "value" is the bytes that were read in base64 encoding
 
 A failure will generate a standard failed response. Please refer to {{failure}}
@@ -951,7 +932,7 @@ definition of failed response.
 
 ### Write multiple values
 
-Method: `PUT /{id}/property`
+Method: `PUT /devices/{id}/properties`
 
 Description: Write values to one or more properties on a device
 
@@ -966,18 +947,16 @@ Request Body:
 Example body updating multiple properties:
 
 ~~~~~
-{
-  "properties": [
-    {
-      "property": "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/temperature",
-      "value": "dGVzdA=="
-    },
-    {
-      "property": "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/humidity",
-      "value": "eGVzdB=="
-    }
-  ]
-}
+[
+  {
+    "property": "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/temperature",
+    "value": "dGVzdA=="
+  },
+  {
+    "property": "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/humidity",
+    "value": "eGVzdB=="
+  }
+]
 ~~~~~
 {:json #exupmprop title="Example updating multiple properties"}
 
@@ -986,25 +965,21 @@ Response:
 Example of a response:
 
 ~~~~~
-{
-  "id": "12345678-1234-5678-1234-56789abcdef4",
-  "properties": [
-    {
-      "property": "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/temperature",
-      "value": "dGVzdA=="
-    },
-    {
-      "property": "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/humidity",
-      "value": "eGVzdB=="
-    }
-  ]
-}
+[
+  {
+    "property": "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/temperature",
+    "value": "dGVzdA=="
+  },
+  {
+    "property": "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/humidity",
+    "value": "eGVzdB=="
+  }
+]
 ~~~~~
 {:json #exupmresp title="Example update multiple properties response"}
 
 where-
 
- - "id" is the id of the device
  - "properties" is an array of properties that were updated, each containing
    a property and a value
 
@@ -1013,7 +988,7 @@ definition of failed response.
 
 ### Read multiple values
 
-Method: `GET /{id}/property`
+Method: `GET /devices/{id}/properties`
 
 Description: Read values from one or more properties on a device
 
@@ -1023,34 +998,30 @@ Parameters:
 
 Query Parameters:
 
- - property: a comma separated list of properties to read
+ - propertyName: a comma separated list of properties to read
 
 Response:
 
 Example of a response:
 
 ~~~~~
-{
-  "id": "12345678-1234-5678-1234-56789abcdef4",
-  "properties": [
-    {
-      "property": "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/temperature",
-      "value": "dGVzdA=="
-    },
-    {
-      "property": "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/humidity",
-      "value": "eGVzdB=="
-    }
-  ]
-}
+[
+  {
+    "property": "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/temperature",
+    "value": "dGVzdA=="
+  },
+  {
+    "property": "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/humidity",
+    "value": "eGVzdB=="
+  }
+]
 ~~~~~
 {:json #exreadmresp title="Example read multiple properties response"}
 
 where-
 
- - "id" is the id of the device
- - "properties" is an array of properties that were read, each containing
-   a property and a value
+ - "property" is the property that was read from
+ - "value" is the bytes that were read in base64 encoding
 
 A failure will generate a standard failed response. Please refer to {{failure}}
 definition of failed response.
@@ -1095,85 +1066,66 @@ used as the MQTT topic instead.
 
 ### Enable event reporting
 
-Method: `POST /{id}/event/{event}`
+Method: `POST /devices/{id}/events/{eventName}`
 
 Description: Enables an event on a specific device
 
 Parameters: 
 
- - id: the id of the device or group of devices
- - event: the event to enable
+ - id: the id of the device
+ - eventName: the event to enable
 
-The event is a URL encoded string that is the absolute URI that is a global
+The eventName is a URL encoded string that is the absolute URI that is a global
 name reference to an `sdfEvent`. 
 
 Response:
 
-Example of a response:
+Returns HTTP status code 201 Created with a Location header pointing to the created event instance.
+
+Example of a successful response:
 
 ~~~~~
-{
-  "id": "12345678-1234-5678-1234-56789abcdef4",
-  "event": "https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected"
-}
+HTTP/1.1 201 Created
+Location: /devices/12345678-1234-5678-1234-56789abcdef4/events/87654321-4321-8765-4321-fedcba9876543
 ~~~~~
-{:json #exenableresp title="Example enable event response"}
 
-where-
-
- - id: the id of the device or group of devices
- - "event" is the event that was enabled
+The Location header contains the URI for the created event instance, which can be used to check status or disable the event.
 
 A failure will generate a standard failed response. Please refer to {{failure}}
 definition of failed response.
 
 ### Disable event reporting
 
-Method: `DELETE /{id}/event/{event}`
+Method: `DELETE /devices/{id}/events/{instanceId}`
 
 Description: Disables an event on a specific device
 
 Parameters:
 
   - id: the id of the device or group of devices
-  - event: the event to disable
-
-The event is a URL encoded string that is the absolute URI that is a global
-name reference to an `sdfEvent`.
+  - instanceId: the instance ID of the event to disable (obtained from the Location header when the event was enabled)
 
 Response:
 
-Example of a response:
+Returns HTTP status code 204 No Content on successful disable.
 
 ~~~~~
-{
-  "id": "12345678-1234-5678-1234-56789abcdef4",
-  "event": "https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected"
-}
+HTTP/1.1 204 No Content
 ~~~~~
-{:json #exdisableresp title="Example disable event response"}
-
-where-
-
- - id: the id of the device or group of devices
- - "event" is the event that was disabled
 
 A failure will generate a standard failed response. Please refer to {{failure}}
 definition of failed response.
 
 ### Get event status
 
-Method: `GET /{id}/event/{event}`
+Method: `GET /devices/{id}/events/{instanceId}`
 
 Description: Get the status of an event on a specific device
 
 Parameters:
 
   - id: the id of the device or group of devices
-  - event: the event to get the status of
-
-The event is a URL encoded string that is the absolute URI that is a global
-name reference to an `sdfEvent`.
+  - instanceId: the instance ID of the event to query
 
 Response:
 
@@ -1181,23 +1133,19 @@ Example of a response:
 
 ~~~~~
 {
-  "id": "12345678-1234-5678-1234-56789abcdef4",
   "event": "https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected"
 }
 ~~~~~
 {:json #exgeteventresp title="Example get event status response"}
 
-where-
-
- - id: the id of the device or group of devices
- - "event" is the event that was queried
+where "event" is the event URI that was enabled for this instance.
 
 A failure will generate a standard failed response. Please refer to {{failure}}
 definition of failed response.
 
 ### Get status of multiple events
 
-Method: `GET /{id}/event`
+Method: `GET /devices/{id}/events`
 
 Description: Get the status of one or more events on a specific device
 
@@ -1207,28 +1155,141 @@ Parameters:
 
 Query Parameters:
 
-  - event: a comma separated list of events to get the status of
+  - instanceId: a comma separated list of event instance IDs to filter by (optional)
 
 Response: 
 
 Example of a response:
 
 ~~~~~
-{
-  "events": [
-    {
-      "id": "12345678-1234-5678-1234-56789abcdef4",
-      "event": "https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected"
-    }
-  ]
-}
+[
+  {
+    "instanceId": "87654321-4321-8765-4321-fedcba9876543",
+    "event": "https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected"
+  }
+]
 ~~~~~
 {:json #exgetmresp title="Example get multiple events status response"}
 
 where-
 
- - "id" is the id of the device or group of devices
- - "events" is an array of events that were queried
+ - "instanceId" is the unique instance ID for each enabled event
+ - "event" is the event URI for each enabled event
+
+A failure will generate a standard failed response. Please refer to {{failure}}
+definition of failed response.
+
+### Enable event reporting on a group of devices
+
+Method: `POST /groups/{id}/events/{eventName}`
+
+Description: Enables an event on a group of devices
+
+Parameters: 
+
+ - id: the id of the group of devices
+ - eventName: the event to enable
+
+The eventName is a URL encoded string that is the absolute URI that is a global
+name reference to an `sdfEvent`. 
+
+Response:
+
+Returns HTTP status code 201 Created with a Location header pointing to the created event instance.
+
+Example of a successful response:
+
+~~~~~
+HTTP/1.1 201 Created
+Location: /groups/12345678-1234-5678-1234-56789abcdef4/events/87654321-4321-8765-4321-fedcba9876543
+~~~~~
+
+The Location header contains the URI for the created event instance, which can be used to check status or disable the event.
+
+A failure will generate a standard failed response. Please refer to {{failure}}
+definition of failed response.
+
+### Disable event reporting on a group of devices
+
+Method: `DELETE /groups/{id}/events/{instanceId}`
+
+Description: Disables an event on a group of devices
+
+Parameters:
+
+  - id: the id of the group of devices
+  - instanceId: the instance ID of the event to disable (obtained from the Location header when the event was enabled)
+
+Response:
+
+Returns HTTP status code 204 No Content on successful disable.
+
+~~~~~
+HTTP/1.1 204 No Content
+~~~~~
+
+A failure will generate a standard failed response. Please refer to {{failure}}
+definition of failed response.
+
+### Get event status on a group of devices
+
+Method: `GET /groups/{id}/events/{instanceId}`
+
+Description: Get the status of an event on a group of devices
+
+Parameters:
+
+ - id: the id of the group of devices
+ - instanceId: the instance ID of the event to check
+
+Response:
+
+Example of a response:
+
+~~~~~
+{
+  "event": "https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected"
+}
+~~~~~
+{:json #exgetgevntresp title="Example get group event status response"}
+
+where "event" is the event URI that was enabled for this instance.
+
+A failure will generate a standard failed response. Please refer to {{failure}}
+definition of failed response.
+
+### Get status of multiple events on a group of devices
+
+Method: `GET /groups/{id}/events`
+
+Description: Get the status of one or more events on a group of devices
+
+Parameters:
+
+ - id: the id of the group of devices
+
+Query Parameters:
+
+  - instanceId: a comma separated list of event instance IDs to filter by (optional)
+
+Response: 
+
+Example of a response:
+
+~~~~~
+[
+  {
+    "instanceId": "87654321-4321-8765-4321-fedcba9876543",
+    "event": "https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected"
+  }
+]
+~~~~~
+{:json #exgetmgevntsresp title="Example get multiple group events status response"}
+
+where-
+
+ - "instanceId" is the unique instance ID for each enabled event
+ - "event" is the event URI for each enabled event
 
 A failure will generate a standard failed response. Please refer to {{failure}}
 definition of failed response.
@@ -1243,30 +1304,44 @@ without modifying it.
 
 ### Perform an action
 
-Method: `PUT /{id}/action/{action}`
+Method: `POST /devices/{id}/actions/{actionName}`
 
 Description: Perform an action on a specific device
 
 Parameters:
 
   - id: the id of the device
-  - action: the action to perform
+  - actionName: the action to perform
 
 Request Body:
 
-  - value: the bytes to be written in base64 encoding.
+The request body is optional and can contain binary data if the underlying protocol 
+allows an action with a value.
 
-The request body is optional and can be empty if the underlying protocol 
-allows an action without a value.
+Response:
 
-Example body of an action:
+Actions are performed asynchronously. A successful request returns HTTP status code 202 Accepted 
+with a Location header pointing to the action instance for status checking.
+
+Example of a successful response:
 
 ~~~~~
-{
-  "value": "dGVzdA=="
-}
+HTTP/1.1 202 Accepted
+Location: /devices/12345678-1234-5678-1234-56789abcdef4/actions/87654321-4321-8765-4321-fedcba9876543
 ~~~~~
-{:json #exaction title="Example action"}
+
+The Location header contains the URI for the action instance, which can be used to check the action status.
+
+### Check action status
+
+Method: `GET /devices/{id}/actions/{instanceId}`
+
+Description: Check the status of an action on a specific device
+
+Parameters:
+
+  - id: the id of the device
+  - instanceId: the instance ID of the action (obtained from the Location header)
 
 Response:
 
@@ -1274,16 +1349,12 @@ Example of a response:
 
 ~~~~~
 {
-  "id": "12345678-1234-5678-1234-56789abcdef4",
-  "action": "https://example.com/heartrate#/sdfObject/healthsensor/sdfAction/start"
+  "status": "COMPLETED"
 }
 ~~~~~
-{:json #exactionresp title="Example action response"}
+{:json #exactionstatusresp title="Example action status response"}
 
-where-
-
- - "id" is the id of the device
- - "action" is the action that was performed
+where "status" indicates the current state of the action (e.g., "IN_PROGRESS" or "COMPLETED").
 
 A failure will generate a standard failed response. Please refer to {{failure}}
 definition of failed response.
@@ -1296,7 +1367,7 @@ connection, so a connection must be established before calling these APIs.
 
 ### Connect to a device
 
-Method: `POST /{id}/action/connection`
+Method: `POST /devices/{id}/manage/connection`
 
 Description: Connect to a device
 
@@ -1435,7 +1506,7 @@ definition of failed response.
 
 ### Update a connection
 
-Method: `PUT /{id}/action/connection`
+Method: `PUT /devices/{id}/manage/connection`
 
 Description: Update cached ServiceMap for a device. Full service discovery will
 be performed, unless specific services are described in the API body.
@@ -1534,7 +1605,7 @@ definition of failed response.
 
 ### Disconnect from a device
 
-Method: `DELETE /{id}/action/connection`
+Method: `DELETE /devices/{id}/manage/connection`
 
 Description: Disconnect from a device
 
@@ -1543,6 +1614,8 @@ Parameters:
   - id: the id of the device
 
 Response:
+
+Returns HTTP status code 200 OK with device ID on successful disconnect.
 
 Example of a response:
 
@@ -1553,16 +1626,14 @@ Example of a response:
 ~~~~~
 {:json #exdisconnresp title="Example disconnect response"}
 
-where-
-
- - "id" is the id of the device
+where "id" is the id of the device.
 
 A failure will generate a standard failed response. Please refer to {{failure}}
 definition of failed response.
 
 ### Get connection status
 
-Method: `GET /{id}/action/connection`
+Method: `GET /devices/{id}/manage/connection`
 
 Description: Get connection status for a device. Success when device(s)
 is/are connected, includes service map for the device if available.
@@ -1608,164 +1679,6 @@ where-
 
   - "id" is the id of the device
   - "protocolMap" contains an Array of BLE services as shown in {{BLEservices}}
-
-A failure will generate a standard failed response. Please refer to {{failure}}
-definition of failed response.
-
-### Write a value using protocol mapping
-
-Method: `POST /{id}/action/property/write`
-
-Description: Writes a value to a property on a device using protocol mapping
-
-Parameters:
-
-  - id: the id of the device
-
-Request Body:
-
-  - value: the bytes to be written in base64 encoding
-  - protocolMap: the protocol mapping for the property
-
-Example body of a write property:
-
-~~~~~
-{
-  "value": "dGVzdA==",
-  "protocolMap": {
-    "ble": {
-      "serviceID": "12345678-1234-5678-1234-56789abcdef4",
-      "characteristicID": "12345678-1234-5678-1234-56789abcdef4"
-    }
-  }
-}
-~~~~~
-{:json #exwriteprop title="Example write property"}
-
-Response:
-
-Example of a response:
-
-~~~~~
-{
-  "id": "12345678-1234-5678-1234-56789abcdef4",
-  "value": "dGVzdA==",
-  "protocolMap": {
-    "ble": {
-      "serviceID": "12345678-1234-5678-1234-56789abcdef4",
-      "characteristicID": "12345678-1234-5678-1234-56789abcdef4"
-    }
-  }
-}
-~~~~~
-{:json #exwritepropresp title="Example write property response"}
-
-where-
-
- - "id" is the id of the device
- - "value" is the bytes that were written in base64 encoding
- - "protocolMap" is the protocol mapping for the property
-
-A failure will generate a standard failed response. Please refer to {{failure}}
-definition of failed response.
-
-### Read a value using protocol mapping
-
-Method: `POST /{id}/action/property/read`
-
-Description: Reads a value from a property on a device using protocol mapping
-
-Parameters:
-
-  - id: the id of the device
-
-Request Body:
-
-  - protocolMap: the protocol mapping for the property
-
-Example body of a read property:
-
-~~~~~
-{
-  "protocolMap": {
-    "ble": {
-      "serviceID": "12345678-1234-5678-1234-56789abcdef4",
-      "characteristicID": "12345678-1234-5678-1234-56789abcdef4"
-    }
-  }
-}
-~~~~~
-{:json #exreadprop title="Example read property"}
-
-Response:
-
-Example of a response:
-
-~~~~~
-{
-  "id": "12345678-1234-5678-1234-56789abcdef4",
-  "value": "dGVzdA==",
-  "protocolMap": {
-    "ble": {
-      "serviceID": "12345678-1234-5678-1234-56789abcdef4",
-      "characteristicID": "12345678-1234-5678-1234-56789abcdef4"
-    }
-  }
-}
-~~~~~
-{:json #exreadpropresp title="Example read property response"}
-
-where-
-
- - "id" is the id of the device
- - "value" is the bytes that were read in base64 encoding
- - "protocolMap" is the protocol mapping for the property
-
-A failure will generate a standard failed response. Please refer to {{failure}}
-definition of failed response.
-
-### Broadcast to a device
-
-Method: `POST /{id}/action/broadcast`
-
-Description: Broadcast a payload to a device. 
-
-Parameters:
-
-  - id: the id of the device
-
-Request Body:
-
-An example body of a broadcast:
-
-~~~~~
-{
-  "id": "12345678-1234-5678-1234-56789abcdef4",
-  "protocolMap": {
-    "ble": {}
-  },
-  "cycle": "single",
-  "broadcastTime": 3000,
-  "broadcastInterval": 500,
-  "payload": "AgEaAgoMFv9MABAHch9BsDkgeA=="
-}
-~~~~~
-{:json #exbroadcast title="Example broadcast"}
-
-where-
-
- - "id" is the id of the device
- - "protocolMap" is the protocol mapping for the property to identify the
-   protocol to be used
- - "cycle" is the broadcast cycle, either "single" or "repeat"
- - "broadcastTime" is the time in milliseconds for the broadcast to run
- - "broadcastInterval" is the time in milliseconds between each broadcast
- - "payload" is the bytes to be broadcast in base64 encoding
-
-Response:
-
-This API responds with a HTTP 200 OK status code and an empty body when
-successful.
 
 A failure will generate a standard failed response. Please refer to {{failure}}
 definition of failed response.
@@ -1828,51 +1741,44 @@ with the actual response once the operation is complete.
 # NIPC Error Handling
 {: #errorhandling}
 
-The error codes in the NIPC APIs can be generic or specific to the API. 
-The generic error codes reuse the HTTP status codes defined in {{!RFC9110}}.
-The error codes for the action APIs are divided into the following
-categories:
+The error codes in the NIPC APIs use URI-based error type identifiers 
+as defined in {{!RFC9457}} Problem Details for HTTP APIs. The error codes 
+can be generic or specific to the API category. The error codes are 
+organized into the following categories:
 
-  - 1000-1099 (Generic): Broadly applicable errors, including 
-    authorization, invalid identifiers, and generic failures.
-  - 1100-1199 (Property APIs): Errors related to property APIs
-    (read/write).
-  - 1200-1299 (Event APIs): Errors related to event APIs
-    (enable/disable).
-  - 1300-1399 (BLE-Specific): Errors specific to BLE operations,
-    including connection management and service discovery.
-  - 1400-1499 (Zigbee-Specific): Errors specific to Zigbee operations.
-  - 1500-1599 (Broadcast APIs): Errors related to broadcasting data.
-  - 1600-1699 (Extension APIs): Errors related to extension APIs.
+  - Generic: Broadly applicable errors, including authorization, 
+    invalid identifiers, and generic failures.
+  - Property APIs: Errors related to property APIs (read/write).
+  - Event APIs: Errors related to event APIs (enable/disable).
+  - Protocol specific: Errors related to protocol-specific operations.
+  - Extension APIs: Errors related to extension APIs.
 
 The specific error codes are defined in the table below:
 
-| Error Code | Description                                  | Category                  |
-|------------|----------------------------------------------|---------------------------|
-| 1000       | Generic catch-all error code for any API      | Generic                   |
-| 1001       | Application not authorized to access the device | Generic                |
-| 1002       | Invalid device ID or gateway doesn't recognize the ID | Generic          |
-| 1003       | Invalid SDF URL or SDF affordance not found   | Generic                   |
-| 1004       | Operation was not executed since the previous operation failed | Generic |
-| 1005       | SDF model already registered                  | Generic                   |
-| 1006       | SDF model in use                              | Generic                   |
-| 1100       | Property not readable                         | Property APIs             |
-| 1101       | Property not writable                         | Property APIs             |
-| 1200       | Event already enabled                         | Event APIs                |
-| 1201       | Event not enabled                             | Event APIs                |
-| 1202       | Event not registered for any data application | Event APIs               |
-| 1300       | Device already connected                      | BLE-Specific              |
-| 1301       | No connection found for device                | BLE-Specific              |
-| 1302       | BLE connection timeout                        | BLE-Specific              |
-| 1303       | BLE bonding failed                            | BLE-Specific              |
-| 1304       | BLE connection failed                         | BLE-Specific              |
-| 1305       | BLE service discovery failed                  | BLE-Specific              |
-| 1306       | Invalid BLE service or characteristic ID      | BLE-Specific              |
-| 1400       | Zigbee connection timeout                     | Zigbee-Specific           |
-| 1401       | Invalid Zigbee endpoint or cluster ID         | Zigbee-Specific           |
-| 1500       | Invalid broadcast data                        | Broadcast APIs            |
-| 1600       | Firmware rollback                             | Extension APIs            |
-| 1601       | Firmware update failed                        | Extension APIs            |
+| Error Code                                      | Description                                  | Category         |
+|-------------------------------------------------|----------------------------------------------|------------------|
+| nipc-invalid-id                                 | Invalid device ID or gateway doesn't recognize the ID | Generic          |
+| nipc-invalid-sdf-url                            | Invalid SDF URL or SDF affordance not found   | Generic           |
+| nipc-extension-operation-not-executed           | Operation was not executed since the previous operation failed | Generic |
+| nipc-sdf-model-already-registered               | SDF model already registered                  | Generic           |
+| nipc-sdf-model-in-use                           | SDF model in use                              | Generic           |
+| nipc-property-not-readable                      | Property not readable                         | Property APIs     |
+| nipc-property-not-writable                      | Property not writable                         | Property APIs     |
+| nipc-event-already-enabled                      | Event already enabled                         | Event APIs        |
+| nipc-event-not-enabled                          | Event not enabled                             | Event APIs        |
+| nipc-event-not-registered                       | Event not registered for any data application | Event APIs        |
+| nipc-protocolmap-ble-already-connected          | Device already connected                      | Protocol specific |
+| nipc-protocolmap-ble-no-connection              | No connection found for device                | Protocol specific |
+| nipc-protocolmap-ble-connection-timeout         | BLE connection timeout                        | Protocol specific |
+| nipc-protocolmap-ble-bonding-failed             | BLE bonding failed                            | Protocol specific |
+| nipc-protocolmap-ble-connection-failed          | BLE connection failed                         | Protocol specific |
+| nipc-protocolmap-ble-service-discovery-failed   | BLE service discovery failed                  | Protocol specific |
+| nipc-protocolmap-ble-invalid-service-or-characteristic | Invalid BLE service or characteristic ID | Protocol specific     |
+| nipc-protocolmap-zigbee-connection-timeout      | Zigbee connection timeout                     | Protocol specific |
+| nipc-protocolmap-zigbee-invalid-endpoint-or-cluster | Invalid Zigbee endpoint or cluster ID     | Protocol specific |
+| nipc-extension-broadcast-invalid-data           | Invalid transmit data                         | Transmit APIs     |
+| nipc-extension-firmware-rollback                | Firmware rollback                             | Extension APIs    |
+| nipc-extension-firmware-update-failed           | Firmware update failed                        | Extension APIs    |
 {: #errorcodes title="Error Codes"}
 
 The appropriate HTTP status code is returned in the response. 
@@ -2016,7 +1922,6 @@ The sequence of operations for this are:
 
     HTTP/1.1 200 OK
     content-type: application/json
-    x-request-id: 1f1c5a37-e21c-4edc-aeb0-65b9d747fe07
 
     {
       "sdfName": "https://example.com/thermometer#/sdfThing/thermometer"
@@ -2034,7 +1939,6 @@ The sequence of operations for this are:
     
     HTTP/1.1 200 OK
     content-type: application/json
-    x-request-id: 7b821223-2ef4-4b7e-8802-efab7e1801ea
     
     {
       "id": "12345678-1234-5678-1234-56789abcdef4",
@@ -2057,7 +1961,6 @@ The sequence of operations for this are:
     
     HTTP/1.1 200 OK
     content-type: application/json
-    x-request-id: 7b821223-2ef4-4b7e-8802-efab7e1801ea
     
     {
       "id": "12345678-1234-5678-1234-56789abcdef4",
@@ -2087,7 +1990,6 @@ The sequence of operations for this are:
 
     HTTP/1.1 200 OK
     content-type: application/json
-    x-request-id: 1f1c5a37-e21c-4edc-aeb0-65b9d747fe07
 
     {
       "sdfName": "https://example.com/thermometer#/sdfThing/thermometer"
@@ -2113,7 +2015,6 @@ The sequence of operations for this are:
 
     HTTP/1.1 200 OK
     content-type: application/json
-    x-request-id: 3a7d9ad6-562e-44ac-b119-cfe1d0e7b74e
 
     {
       "id": "12345678-1234-5678-1234-56789abcdef4",
@@ -2134,7 +2035,6 @@ The sequence of operations for this are:
     
     HTTP/1.1 200 OK
     content-type: application/json
-    x-request-id: 1f1c5a37-e21c-4edc-aeb0-65b9d747fe07
 
     {
       "id": "12345678-1234-5678-1234-56789abcdef4",
@@ -2153,7 +2053,7 @@ The sequence of operations for this are:
   - Connect to the device
 
     ~~~~~
-    POST /12345678-1234-5678-1234-56789abcdef4/action/connection
+    POST /devices/12345678-1234-5678-1234-56789abcdef4/manage/connection
     Content-Type: application/json
     Accept: application/json
     Host: localhost
@@ -2181,7 +2081,6 @@ The sequence of operations for this are:
 
     HTTP/1.1 200 OK
     content-type: application/json
-    x-request-id: 7b821223-2ef4-4b7e-8802-efab7e1801ea
     
     {
       "id": "12345678-1234-5678-1234-56789abcdef4",
@@ -2212,7 +2111,7 @@ The sequence of operations for this are:
   - Read a property from the BLE device
 
     ~~~~~
-    POST /12345678-1234-5678-1234-56789abcdef4/action/property/read
+    POST /extensions/12345678-1234-5678-1234-56789abcdef4/action/property/read
     Content-Type: application/json
     Accept: application/json
     Host: localhost
@@ -2228,7 +2127,6 @@ The sequence of operations for this are:
     
     HTTP/1.1 200 OK
     content-type: application/json
-    x-request-id: 7b821223-2ef4-4b7e-8802-efab7e1801ea
     
     {
       "id": "12345678-1234-5678-1234-56789abcdef4",
@@ -2245,7 +2143,7 @@ The sequence of operations for this are:
   - Write to a property on the BLE device
 
     ~~~~~
-    POST /12345678-1234-5678-1234-56789abcdef4/action/property/write
+    POST /extensions/12345678-1234-5678-1234-56789abcdef4/action/property/write
     Content-Type: application/json
     Accept: application/json
     Host: localhost
@@ -2262,7 +2160,6 @@ The sequence of operations for this are:
     
     HTTP/1.1 200 OK
     content-type: application/json
-    x-request-id: 7b821223-2ef4-4b7e-8802-efab7e1801ea
     
     {
       "id": "12345678-1234-5678-1234-56789abcdef4",
@@ -2279,13 +2176,12 @@ The sequence of operations for this are:
   - Disconnect from the device
 
     ~~~~~
-    DELETE /12345678-1234-5678-1234-56789abcdef4/action/connection
+    DELETE /devices/12345678-1234-5678-1234-56789abcdef4/manage/connection
     Accept: application/json
     Host: localhost
     
     HTTP/1.1 200 OK
     content-type: application/json
-    x-request-id: 7b821223-2ef4-4b7e-8802-efab7e1801ea
     
     {
       "id": "12345678-1234-5678-1234-56789abcdef4"
@@ -2317,6 +2213,10 @@ with {{!RFC8126}}.
 ## Protocol mapping
 
 ## API extensions
+
+## Well-known URIs
+
+## Problem Details for HTTP APIs
 
 --- back
 
@@ -2422,6 +2322,15 @@ file "Extension-Firmware.yaml"
 <CODE BEGINS>
 file "Extension-ReadConditional.yaml"
 {::include nipc-openapi/extensions/Extension-ReadConditional.yaml}
+<CODE ENDS>
+~~~~~
+
+## NIPC API property extensions
+
+~~~~~
+<CODE BEGINS>
+file "Extension-Property.yaml"
+{::include nipc-openapi/extensions/Extension-Property.yaml}
 <CODE ENDS>
 ~~~~~
 

--- a/draft-ietf-asdf-nipc.mkd
+++ b/draft-ietf-asdf-nipc.mkd
@@ -2111,7 +2111,7 @@ The sequence of operations for this are:
   - Read a property from the BLE device
 
     ~~~~~
-    POST /extensions/12345678-1234-5678-1234-56789abcdef4/action/property/read
+    POST /extensions/12345678-1234-5678-1234-56789abcdef4/properties/read
     Content-Type: application/json
     Accept: application/json
     Host: localhost
@@ -2143,7 +2143,7 @@ The sequence of operations for this are:
   - Write to a property on the BLE device
 
     ~~~~~
-    POST /extensions/12345678-1234-5678-1234-56789abcdef4/action/property/write
+    POST /extensions/12345678-1234-5678-1234-56789abcdef4/properties/write
     Content-Type: application/json
     Accept: application/json
     Host: localhost

--- a/draft-ietf-asdf-nipc.mkd
+++ b/draft-ietf-asdf-nipc.mkd
@@ -717,13 +717,13 @@ that is registered with the SCIM server. The endpoint app is defined in
 
 ### Register a data application
 
-Method: `POST /registration/data-app/{data-app-id}`
+Method: `POST /registration/data-app/{dataAppId}`
 
 Description: Registers a data application with the gateway
 
 Parameters: 
 
- - data-app-id: the id of the data application
+ - dataAppId: the id of the data application
 
 Request Body:
 
@@ -798,13 +798,13 @@ If successful, the response will be identical to the request body.
 
 ### Update a data application
 
-Method: `PUT /registration/data-app/{data-app-id}`
+Method: `PUT /registration/data-app/{dataAppId}`
 
 Description: Updates a data application with the gateway
 
 Parameters: 
 
- - data-app-id: the id of the data application
+ - dataAppId: the id of the data application
 
 Request Body: Same as the request body for the register data application API.
 
@@ -814,13 +814,13 @@ If successful, the response will be identical to the request body.
 
 ### Get a data application
 
-Method: `GET /registration/data-app/{data-app-id}`
+Method: `GET /registration/data-app/{dataAppId}`
 
 Description: Gets a data application registered with the gateway
 
 Parameters: 
 
- - data-app-id: the id of the data application
+ - dataAppId: the id of the data application
 
 Response:
 
@@ -829,13 +829,13 @@ application API.
 
 ### Delete a data application
 
-Method: `DELETE /registration/data-app/{data-app-id}`
+Method: `DELETE /registration/data-app/{dataAppId}`
 
 Description: Deletes a data application registered with the gateway
 
 Parameters: 
 
- - data-app-id: the id of the data application
+ - dataAppId: the id of the data application
 
 Response:
 
@@ -1052,7 +1052,7 @@ and the event is
 the topic will be:
 
 ~~~~~
-data-app/<data-app-id>/<namespace>/<json_pointer_to_sdf_event>
+data-app/<dataAppId>/<namespace>/<json_pointer_to_sdf_event>
 
 data-app/12345678-1234-5678-1234-56789abcdef4/thermometer/sdfObject/thermometer/sdfEvent/isPresent
 ~~~~~

--- a/nipc-openapi/NIPC.yaml
+++ b/nipc-openapi/NIPC.yaml
@@ -18,7 +18,7 @@ externalDocs:
   description: NIPC IETF draft
   url: https://datatracker.ietf.org/doc/draft-ietf-asdf-nipc/
 servers:
-  - url: "{gw_host}/nipc/draft-05"
+  - url: "{gw_host}/nipc/draft-07"
     variables:
       gw_host:
         default: localhost
@@ -48,7 +48,7 @@ tags:
 
 paths:
 ### NIPC Property APIs
-  /{id}/properties/{propertyName}:
+  /devices/{id}/properties/{propertyName}:
     put:
       tags:
         - NIPC property APIs
@@ -74,6 +74,9 @@ paths:
           example: "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/temperature"
       requestBody:
         content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Value'
           application/octet-stream:
             schema:
               type: string
@@ -87,9 +90,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/PropertyErrorCodes'
+                $ref: '#/components/schemas/FailureResponse'
 
     get:
       tags:
@@ -118,6 +119,9 @@ paths:
         '200':
           description: Success
           content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Value'
             application/octet-stream:
               schema:
                 type: string
@@ -127,11 +131,9 @@ paths:
           content:
             application/problem+json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/PropertyErrorCodes'
+                $ref: '#/components/schemas/FailureResponse'
 
-  /{id}/properties:
+  /devices/{id}/properties:
     put:
       tags:
         - NIPC property APIs
@@ -167,9 +169,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/PropertyErrorCodes'
+                $ref: '#/components/schemas/FailureResponse'
 
     get:
       tags:
@@ -190,6 +190,7 @@ paths:
       - name: propertyName
         in: query
         description: Properties to be read
+        required: true
         schema:
           type: array
           items:
@@ -209,12 +210,10 @@ paths:
           content:
             application/problem+json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/PropertyErrorCodes'
+                $ref: '#/components/schemas/FailureResponse'
  
  ### NIPC Event APIs
-  /{id}/events/{eventName}:
+  /devices/{id}/events/{eventName}:
     post:
       tags:
         - NIPC event APIs
@@ -247,17 +246,15 @@ paths:
               schema:
                 type: string
                 format: uri
-                example: "/{id}/event/{instanceId}"
+                example: "/devices/{id}/event/{instanceId}"
         default:
           description: Error response
           content:
             application/problem+json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/EventErrorCodes'
+                $ref: '#/components/schemas/FailureResponse'
   
-  /{id}/events/{instanceId}:
+  /devices/{id}/events/{instanceId}:
     delete:
       tags:
         - NIPC event APIs
@@ -290,9 +287,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/EventErrorCodes'
+                $ref: '#/components/schemas/FailureResponse'
                 
     get:
       tags:
@@ -331,11 +326,9 @@ paths:
           content:
             application/problem+json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/EventErrorCodes'
+                $ref: '#/components/schemas/FailureResponse'
 
-  /{id}/events:
+  /devices/{id}/events:
     get:
       tags:
         - NIPC event APIs
@@ -374,12 +367,162 @@ paths:
           content:
             application/problem+json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/EventErrorCodes'
+                $ref: '#/components/schemas/FailureResponse'
+
+  /groups/{id}/events/{eventName}:
+    post:
+      tags:
+        - NIPC event APIs
+      summary: Enable an event on a group of devices
+      description: |-
+        Enable an event on a group of devices. If the underlying protocol requires a connection to be set up, this API call will perform the necessary connection management. If a connection is already active for this device, the existing connection will be leveraged without modifying it.
+      operationId: EnableGroupEvent
+      parameters:
+      - name: id
+        in: path
+        description: group id for which the event needs to be enabled
+        required: true
+        schema:
+          type: string
+          format: uuid
+          example: 12345678-1234-5678-1234-56789abcdef4
+      - name: eventName
+        in: path
+        description: event that needs to be enabled
+        required: true
+        schema:
+          type: string
+          example: "https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected"
+      responses:
+        '201':
+          description: Success, event enabled
+          headers:
+            Location:
+              description: Location of the created event
+              schema:
+                type: string
+                format: uri
+                example: "/groups/{id}/event/{instanceId}"
+        default:
+          description: Error response
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
+  /groups/{id}/events/{instanceId}:
+    delete:
+      tags:
+        - NIPC event APIs
+      summary: Disable an event on a group of devices
+      description: |-
+        Disable an event on a group of devices. If the underlying protocol requires a connection to be set up, this API call will perform the necessary connection management. If a connection is already active for this device, the existing connection will be leveraged without modifying it.
+      operationId: DisableGroupEvent
+      parameters:
+      - name: id
+        in: path
+        description: group id for which the event needs to be disabled
+        required: true
+        schema:
+          type: string
+          format: uuid
+          example: 12345678-1234-5678-1234-56789abcdef4
+      - name: instanceId
+        in: path
+        description: instance id of the event that needs to be disabled
+        required: true
+        schema:
+          type: string
+          format: uuid
+          example: 12345678-1234-5678-1234-56789abcdef4
+      responses:
+        '204':
+          description: Success, no content
+        default:
+          description: Error response
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
+    get:
+      tags:
+        - NIPC event APIs
+      summary: Get status of an event on a group of devices
+      description: |-
+        Get status of an event on a group of devices. Success is event is active, failure if event not active.
+      operationId: GetGroupEvent
+      parameters:
+      - name: id
+        in: path
+        description: group id for which the event needs to be checked
+        required: true
+        schema:
+          type: string
+          format: uuid
+          example: 12345678-1234-5678-1234-56789abcdef4
+      - name: instanceId
+        in: path
+        description: instance id of the event that needs to be checked
+        required: true
+        schema:
+          type: string
+          format: uuid
+          example: 12345678-1234-5678-1234-56789abcdef4
+      responses:
+        '200':
+          description: Success, event is active
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
+        default:
+          description: Error response
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
+  /groups/{id}/events:
+    get:
+      tags:
+        - NIPC event APIs
+      summary: Get status of events on a group of devices
+      description: |-
+        Get status of an event or multiple events on a group of devices.
+      operationId: GetGroupEvents
+      parameters:
+      - name: id
+        in: path
+        description: group id of the SCIM group
+        required: true
+        schema:
+          type: string
+          format: uuid
+          example: 12345678-1234-5678-1234-56789abcdef4
+      - name: instanceId
+        in: query
+        description: Instance IDs of the events that need to be filtered
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+            example: 12345678-1234-5678-1234-56789abcdef4
+      responses:
+        '200':
+          description: Success, events retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventStatusResponseArray'
+        default:
+          description: Error response
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/FailureResponse'
 
 ### NIPC action APIs
-  /{id}/actions/{actionName}:
+  /devices/{id}/actions/{actionName}:
     post:
       tags:
         - NIPC action APIs
@@ -419,16 +562,14 @@ paths:
               schema:
                 type: string
                 format: uri
-                example: "/{id}/actions/{instanceId}"
+                example: "/devices/{id}/actions/{instanceId}"
         default:
           description: Error response
           content:
             application/problem+json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/PropertyErrorCodes'
-  /{id}/actions/{instanceId}:
+                $ref: '#/components/schemas/FailureResponse'
+  /devices/{id}/actions/{instanceId}:
     get:
       tags:
         - NIPC action APIs
@@ -459,52 +600,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Action'
+                $ref: '#/components/schemas/ActionResponse'
         default:
           description: Error response
           content:
             application/problem+json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/PropertyErrorCodes'
-                  
-  /{id}/action/broadcast:
-    post:
-      tags:
-        - NIPC action APIs with embedded protocol mapping
-      summary: Broadcast to a device
-      description: |-
-        Broadcast a payload to a device. The broadcast is performed on the AP where the device was last seen
-      operationId: ActionBroadcast
-      parameters:
-        - name: id
-          in: path
-          description: device id that need to be filtered, group id not allowed
-          required: true
-          schema:
-            type: string
-            format: uuid
-            example: 12345678-1234-5678-1234-56789abcdef4
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Broadcast'
-        required: true
-      responses:
-        '200':
-          description: Success
-        default:
-          description: Error response
-          content:
-            application/problem+json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/BroadcastErrorCodes'
-                  
-  /{id}/action/connection:
+                $ref: '#/components/schemas/FailureResponse'
+               
+  /devices/{id}/manage/connection:
     post:
       tags:
         - NIPC action APIs with embedded protocol mapping
@@ -543,10 +647,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/ConnectionErrorCodes'
-                  - $ref: './protocolmaps/ProtocolMap.yaml#/components/schemas/ProtocolMap-ErrorCodes'
+                $ref: '#/components/schemas/FailureResponse'
   
     put:
       tags:
@@ -584,10 +685,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/ConnectionErrorCodes'
-                  - $ref: './protocolmaps/ProtocolMap.yaml#/components/schemas/ProtocolMap-ErrorCodes'
+                $ref: '#/components/schemas/FailureResponse'
   
     delete:
       tags:
@@ -618,9 +716,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/ConnectionErrorCodes'
+                $ref: '#/components/schemas/FailureResponse'
                   
     get:
       tags:
@@ -652,98 +748,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/ConnectionErrorCodes'
-                  - $ref: './protocolmaps/ProtocolMap.yaml#/components/schemas/ProtocolMap-ErrorCodes'
- 
-  /{id}/action/property/write:
-    post:
-      tags:
-        - NIPC action APIs with embedded protocol mapping
-      summary: Write a value to an property using protocol mapping
-      description: |-
-        Write a value to an unregistered property, embedding property protocol mapping in the API, this does not require
-        property registration. You cannot write to a group id.
-      operationId: ActionPropWrite
-      parameters:
-        - name: id
-          in: path
-          description: device id that need to be filtered, group id not allowed
-          required: true
-          schema:
-            type: string
-            format: uuid
-            example: 12345678-1234-5678-1234-56789abcdef4
-      requestBody:
-        content:
-          application/json:
-            schema:
-              allOf:
-                - $ref: '#/components/schemas/Value' 
-                - $ref: './protocolmaps/ProtocolMap.yaml#/components/schemas/ProtocolMap-Property'
-        required: true
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                allOf: 
-                  - $ref: '#/components/schemas/Id'
-                  - $ref: '#/components/schemas/Value'
-                  - $ref: './protocolmaps/ProtocolMap.yaml#/components/schemas/ProtocolMap-Property'
-        default:
-          description: Error response
-          content:
-            application/problem+json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/PropertyErrorCodes'
-                
-  /{id}/action/property/read:
-    post:
-      tags:
-        - NIPC action APIs with embedded protocol mapping
-      summary: Read a value to an property using protocol mapping
-      description: |-
-        Read a value from an unregistered property, embedding property protocol mapping in the API, this does not require
-        property registration. You cannot read from a group id.
-      operationId: ActionPropRead
-      parameters:
-        - name: id
-          in: path
-          description: device id that need to be filtered, group id not allowed
-          required: true
-          schema:
-            type: string
-            format: uuid
-            example: 12345678-1234-5678-1234-56789abcdef4
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: './protocolmaps/ProtocolMap.yaml#/components/schemas/ProtocolMap-Property'
-        required: true
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                allOf: 
-                  - $ref: '#/components/schemas/Id'
-                  - $ref: '#/components/schemas/Value'
-                  - $ref: './protocolmaps/ProtocolMap.yaml#/components/schemas/ProtocolMap-Property'
-        default:
-          description: Error response
-          content:
-            application/problem+json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/PropertyErrorCodes'
+                $ref: '#/components/schemas/FailureResponse'
 
 
 ### Registrations
@@ -767,8 +772,10 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/SdfReference'
+                type: array
+                items:
+                  allOf:
+                    - $ref: '#/components/schemas/SdfReference'
         default:
           description: Error response
           content:
@@ -1069,16 +1076,17 @@ components:
           type: string
           example: "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/temperature"
 
-    Action:
+    ActionResponse:
       required:
         - action
       type: object
       properties:
-        action:
+        status:
           type: string
-          example: "https://example.com/heartrate#/sdfObject/thermostat/sdfAction/start"
+          example: COMPLETED
+          description: Status of the action, can be IN_PROGRESS or COMPLETED
 
-## A value 
+## A value
     Value:
       required:
         - value
@@ -1093,11 +1101,6 @@ components:
     PropertyValue:
       allOf:
         - $ref: '#/components/schemas/Property'
-        - $ref: '#/components/schemas/Value'
-
-    ActionValue:
-      allOf:
-        - $ref: '#/components/schemas/Action'
         - $ref: '#/components/schemas/Value'
 
 ## An array of Property values
@@ -1116,6 +1119,15 @@ components:
           type: string
           description: percent-encoded JSON pointer to the SDF event object
           example: https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected
+
+    InstanceId:
+      type: object
+      properties:
+        instanceId:
+          type: string
+          format: uuid
+          description: A SCIM-generated UUID for the event instance
+          example: 12345678-1234-5678-1234-56789abcdef4
             
 ## A Connection
     Connection:
@@ -1128,34 +1140,6 @@ components:
         retryMultipleAPs:
           type: boolean
           example: true
-        
-## A broadcast
-    Broadcast:
-      allOf:
-        - $ref: '#/components/schemas/Id'
-        - $ref: './protocolmaps/ProtocolMap.yaml#/components/schemas/ProtocolMap-Broadcast'
-      required:
-        - cycle
-      type: object
-      properties:
-        cycle:
-          type: string
-          example: single
-          enum:
-            - single
-            - repeat
-        # broadcast time in ms
-        broadcastTime:
-          type: integer
-          example: 3000
-        # interval between broadcasts in ms
-        broadcastInterval:
-          type: integer
-          example: 500
-        payload:
-          type: string
-          format: byte
-          example: AgEaAgoMFv9MABAHch9BsDkgeA==
           
  ## DataApp
     DataApp:
@@ -1407,8 +1391,31 @@ components:
       properties:
         type:
           type: string
-          example: https://www.iana.org/assignments/http-problem-types#server-error
           description: URI to the error type
+          enum:
+            - https://www.iana.org/assignments/http-problem-types#nipc-invalid-id
+            - https://www.iana.org/assignments/http-problem-types#nipc-invalid-sdf-url
+            - https://www.iana.org/assignments/http-problem-types#nipc-extension-operation-not-executed
+            - https://www.iana.org/assignments/http-problem-types#nipc-sdf-model-already-registered
+            - https://www.iana.org/assignments/http-problem-types#nipc-sdf-model-in-use
+            - https://www.iana.org/assignments/http-problem-types#nipc-property-not-readable
+            - https://www.iana.org/assignments/http-problem-types#nipc-property-not-writable
+            - https://www.iana.org/assignments/http-problem-types#nipc-event-already-enabled
+            - https://www.iana.org/assignments/http-problem-types#nipc-event-not-enabled
+            - https://www.iana.org/assignments/http-problem-types#nipc-event-not-registered
+            - https://www.iana.org/assignments/http-problem-types#nipc-protocolmap-ble-already-connected
+            - https://www.iana.org/assignments/http-problem-types#nipc-protocolmap-ble-no-connection
+            - https://www.iana.org/assignments/http-problem-types#nipc-protocolmap-ble-connection-timeout
+            - https://www.iana.org/assignments/http-problem-types#nipc-protocolmap-ble-bonding-failed
+            - https://www.iana.org/assignments/http-problem-types#nipc-protocolmap-ble-connection-failed
+            - https://www.iana.org/assignments/http-problem-types#nipc-protocolmap-ble-service-discovery-failed
+            - https://www.iana.org/assignments/http-problem-types#nipc-protocolmap-ble-invalid-service-or-characteristic
+            - https://www.iana.org/assignments/http-problem-types#nipc-protocolmap-zigbee-connection-timeout
+            - https://www.iana.org/assignments/http-problem-types#nipc-protocolmap-zigbee-invalid-endpoint-or-cluster
+            - https://www.iana.org/assignments/http-problem-types#nipc-extension-broadcast-invalid-data
+            - https://www.iana.org/assignments/http-problem-types#nipc-extension-firmware-rollback
+            - https://www.iana.org/assignments/http-problem-types#nipc-extension-firmware-update-failed
+            - about:blank
         status:
           type: integer
           format: int32
@@ -1416,71 +1423,12 @@ components:
           description: HTTP status code
         title:
           type: string
-          example: NIPC server error
+          example: Invalid Device ID
           description: Human-readable error title
         detail:
           type: string
-          example: Bad request
-          description: Human-readable error message
-        nipcStatus:
-          type: integer
-          format: int32
-          description: NIPC error code
-          enum: 
-            - 1000 # Generic catch-all error code for any API
-            - 1001 # Application not authorized to access the device
-            - 1002 # Invalid device ID or gateway doesn't recognize the ID
-            - 1003 # Invalid SDF URL or SDF affordance not found
-            - 1004 # Operation was not executed since the previous operation failed
-            - 1005 # SDF model already registered
-            - 1006 # SDF model in use
-
-    PropertyErrorCodes:
-      type: object
-      properties:
-        nipcStatus:
-          type: integer
-          format: int32
-          enum:
-            - 1100 # Property not readable
-            - 1101 # Property not writable
-
-    EventErrorCodes:
-      type: object
-      properties:
-        nipcStatus:
-          type: integer
-          format: int32
-          enum:
-            - 1200 # Event already enabled
-            - 1201 # Event not enabled
-            - 1202 # Event not registered for any data application
-
-    ConnectionErrorCodes:
-      type: object
-      properties:
-        nipcStatus:
-          type: integer
-          format: int32
-          enum:
-            - 1300 # Device already connected
-            - 1301 # No connection found for device
-            - 1302 # BLE connection timeout
-            - 1303 # BLE bonding failed
-            - 1304 # BLE connection failed
-            - 1305 # BLE service discovery failed
-            - 1306 # Invalid BLE service or characteristic ID
-            - 1400 # Zigbee connection timeout
-            - 1401 # Invalid Zigbee endpoint or cluster ID
-
-    BroadcastErrorCodes:
-      type: object
-      properties:
-        nipcStatus:
-          type: integer
-          format: int32
-          enum:
-            - 1500 # Invalid broadcast data        
+          example: Device ID 12345678-1234-5678-1234-56789abcdef4 does not exist or is not a device
+          description: Human-readable error message  
 
 ## Property operations responses
     
@@ -1497,7 +1445,9 @@ components:
 ## Event operations responses
     EventStatusResponseArrayItem:
       oneOf:
-        - $ref: '#/components/schemas/Event'
+        - allOf:
+          - $ref: '#/components/schemas/Event'
+          - $ref: '#/components/schemas/InstanceId'
         - $ref: '#/components/schemas/FailureResponse'
 
     EventStatusResponseArray:

--- a/nipc-openapi/NIPC.yaml
+++ b/nipc-openapi/NIPC.yaml
@@ -244,7 +244,7 @@ paths:
               schema:
                 type: string
                 format: uri
-                example: "/devices/{id}/event/{instanceId}"
+                example: "/devices/{id}/events/{instanceId}"
         default:
           description: Error response
           content:
@@ -400,7 +400,7 @@ paths:
               schema:
                 type: string
                 format: uri
-                example: "/groups/{id}/event/{instanceId}"
+                example: "/groups/{id}/events/{instanceId}"
         default:
           description: Error response
           content:

--- a/nipc-openapi/NIPC.yaml
+++ b/nipc-openapi/NIPC.yaml
@@ -37,11 +37,9 @@ tags:
   - name: NIPC action APIs
     description: |-
       APIs that perform actions on devices.
-  - name: NIPC action APIs with embedded protocol mapping
+  - name: NIPC management APIs
     description: |-
-      APIs that perform actions on devices, but do not use registered
-      properties, events or actions. These APIs have embedded protocol
-      mappings
+      APIs that manage device connections.
   - name: NIPC registration APIs
     description: |-
       APIs that register sdf models or data applications
@@ -59,7 +57,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id is not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string
@@ -102,7 +100,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id is not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string
@@ -144,7 +142,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id is not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string
@@ -181,7 +179,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id is not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string
@@ -332,14 +330,14 @@ paths:
     get:
       tags:
         - NIPC event APIs
-      summary: Get status of events on a device or group of devices
+      summary: Get status of events on a device
       description: |-
-        Get status of an event or multiple events on a specific device or group of devices.
+        Get status of an event or multiple events on a specific device
       operationId: GetEvents
       parameters:
       - name: id
         in: path
-        description: device or group id that needs to be filtered
+        description: The ID of the device.
         required: true
         schema:
           type: string
@@ -347,7 +345,7 @@ paths:
           example: 12345678-1234-5678-1234-56789abcdef4
       - name: instanceId
         in: query
-        description: Instance IDs of the events that need to be filtered
+        description: Instance ID of the events that need to be filtered
         required: false
         schema:
           type: array
@@ -533,7 +531,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id is not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string
@@ -580,7 +578,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string
@@ -611,7 +609,7 @@ paths:
   /devices/{id}/manage/connection:
     post:
       tags:
-        - NIPC action APIs with embedded protocol mapping
+        - NIPC management APIs
       summary: Connect a device
       description: |-
         Connect a device. 3 retries by default, optionally retry policy can be defined in the API body. If the protocol requires service discovery, full service discovery will be performed, unless specific services are described in the API body.
@@ -619,7 +617,7 @@ paths:
       parameters:
         - name: id
           in: path
-          description: device id that need to be filtered, group id not allowed
+          description: The ID of the device. Group ID is not allowed.
           required: true
           schema:
             type: string
@@ -659,7 +657,7 @@ paths:
       parameters:
         - name: id
           in: path
-          description: device id that need to be filtered, group id not allowed
+          description: The ID of the device. Group ID is not allowed.
           required: true
           schema:
             type: string
@@ -697,7 +695,7 @@ paths:
       parameters:
         - name: id
           in: path
-          description: device id that need to be filtered, group id not allowed
+          description: The ID of the device. Group ID is not allowed.
           required: true
           schema:
             type: string
@@ -728,7 +726,7 @@ paths:
       parameters:
         - name: id
           in: path
-          description: device id that need to be filtered, group id not allowed
+          description: The ID of the device. Group ID is not allowed.
           required: true
           schema:
             type: string
@@ -787,9 +785,9 @@ paths:
     get:
       tags:
         - NIPC registration APIs
-      summary: Get all registered sdfRefs
+      summary: Get all registered SDF model names
       description: |-
-        Get all registered sdfRefs for a device or group
+        Get all registered SDF model names.
       operationId: getSdfRefs
       responses:
         '200':

--- a/nipc-openapi/NIPC.yaml
+++ b/nipc-openapi/NIPC.yaml
@@ -1,15 +1,19 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
 openapi: 3.0.3
 info:
   title: Non IP Device Control (NIPC) API
   description: |-
-    This API specifies RESTful application layer interface for gateways providing operations against non-IP devices. The described interface is extensible. The examples includes leverage Bluetooth Low Energy and Zigbee as they are commonly deployed.
+    This API specifies RESTful application layer interface for gateways
+    providing operations against non-IP devices. The described interface
+    is extensible. The examples includes leverage Bluetooth Low Energy
+    and Zigbee as they are commonly deployed.
   termsOfService: http://swagger.io/terms/
   contact:
     email: bbrinckm@cisco.com
   license:
     name: TBD
     url: TBD
-  version: 0.5.2
+  version: 0.5.3
 externalDocs:
   description: NIPC IETF draft
   url: https://datatracker.ietf.org/doc/draft-ietf-asdf-nipc/
@@ -22,23 +26,29 @@ servers:
 tags:
   - name: NIPC property APIs
     description: |-
-      APIs that allow apps to get and update device properties. If the underlying protocol requires connection management, it will be performed as part of the API call.
+      APIs that allow apps to get and update device properties.
+      If the underlying protocol requires connection management,
+      it will be performed as part of the API call.
   - name: NIPC event APIs
     description: |-
-      APIs that allow apps to enable or disable event reporting on devices. If the underlying protocol requires connection management, it will be performed as part of the API call.
+      APIs that allow apps to enable or disable event reporting on 
+      devices. If the underlying protocol requires connection
+      management, it will be performed as part of the API call.
   - name: NIPC action APIs
     description: |-
       APIs that perform actions on devices.
   - name: NIPC action APIs with embedded protocol mapping
     description: |-
-      APIs that perform actions on devices, but do not use registered properties, events or actions. These APIs have embedded protocol mappings
+      APIs that perform actions on devices, but do not use registered
+      properties, events or actions. These APIs have embedded protocol
+      mappings
   - name: NIPC registration APIs
     description: |-
       APIs that register sdf models or data applications
 
 paths:
 ### NIPC Property APIs
-  /{id}/property/{property}:
+  /{id}/properties/{propertyName}:
     put:
       tags:
         - NIPC property APIs
@@ -55,43 +65,27 @@ paths:
           type: string
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
-      - name: property
+      - name: propertyName
         in: path
-        description: property that needs to be filtered
+        description: the property to write to
         required: true
         schema:
           type: string
           example: "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/temperature"
       requestBody:
         content:
-          application/json:
+          application/octet-stream:
             schema:
-              $ref: '#/components/schemas/Value'
+              type: string
+              format: binary
         required: true
       responses:
-        '200':
-          description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
+        '204':
+          description: Success, no content
+        default:
+          description: Error response
           content:
-            application/json:
-              schema:
-                allOf: 
-                  - $ref: '#/components/schemas/Id'
-                  - $ref: '#/components/schemas/PropertyValue'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
-          content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse' 
@@ -113,9 +107,9 @@ paths:
           type: string
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
-      - name: property
+      - name: propertyName
         in: path
-        description: property that needs to be filtered
+        description: the property to read from
         required: true
         schema:
           type: string
@@ -123,33 +117,21 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
+          content:
+            application/octet-stream:
               schema:
                 type: string
-              description: Unique Request ID
+                format: binary
+        default:
+          description: Error response
           content:
-            application/json:
-              schema:
-                allOf: 
-                  - $ref: '#/components/schemas/Id'
-                  - $ref: '#/components/schemas/PropertyValue'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
-          content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse' 
                   - $ref: '#/components/schemas/PropertyErrorCodes'
 
-  /{id}/property:
+  /{id}/properties:
     put:
       tags:
         - NIPC property APIs
@@ -175,29 +157,19 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf: 
-                  - $ref: '#/components/schemas/Id'
                   - $ref: '#/components/schemas/PropertyValueResponseArray'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request       
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/FailureResponse' 
+                allOf:
+                  - $ref: '#/components/schemas/FailureResponse' 
+                  - $ref: '#/components/schemas/PropertyErrorCodes'
 
     get:
       tags:
@@ -215,11 +187,9 @@ paths:
           type: string
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
-      - name: property
+      - name: propertyName
         in: query
-        description: properties that needs to be filtered, multiple values are comma-separated
-        required: true
-        explode: false
+        description: Properties to be read
         schema:
           type: array
           items:
@@ -228,34 +198,23 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf: 
                   - $ref: '#/components/schemas/Id'
                   - $ref: '#/components/schemas/PropertyValueResponseArray'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse' 
                   - $ref: '#/components/schemas/PropertyErrorCodes'
  
  ### NIPC Event APIs
-  /{id}/event/{event}:
+  /{id}/events/{eventName}:
     post:
       tags:
         - NIPC event APIs
@@ -272,7 +231,7 @@ paths:
           type: string
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
-      - name: event
+      - name: eventName
         in: path
         description: event that needs to be enabled
         required: true
@@ -280,35 +239,25 @@ paths:
           type: string
           example: "https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected"
       responses:
-        '200':
+        '201':
           description: Success
           headers:
-            X-Request-ID:
+            Location:
+              description: Location of the created event
               schema:
                 type: string
-              description: Unique Request ID
+                format: uri
+                example: "/{id}/event/{instanceId}"
+        default:
+          description: Error response
           content:
-            application/json:
-              schema:
-                allOf: 
-                  - $ref: '#/components/schemas/Id'
-                  - $ref: '#/components/schemas/Event'                  
-                
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request 
-        '500':
-          description: Server-side failure
-          content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse' 
                   - $ref: '#/components/schemas/EventErrorCodes'
   
+  /{id}/events/{instanceId}:
     delete:
       tags:
         - NIPC event APIs
@@ -325,37 +274,21 @@ paths:
           type: string
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
-      - name: event
+      - name: instanceId
         in: path
-        description: event that needs to be disabled
+        description: instance id of the event that needs to be disabled
         required: true
         schema:
           type: string
-          example: "https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected"
+          format: uuid
+          example: 12345678-1234-5678-1234-56789abcdef4
       responses:
-        '200':
-          description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
+        '204':
+          description: Success, no content
+        default:
+          description: Error response
           content:
-            application/json:
-              schema:
-                allOf: 
-                  - $ref: '#/components/schemas/Id'  
-                  - $ref: '#/components/schemas/Event' 
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
-          content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse' 
@@ -377,43 +310,32 @@ paths:
           type: string
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
-      - name: event
+      - name: instanceId
         in: path
-        description: event that needs to be filtered
+        description: instance id of the event that needs to be checked
         required: true
         schema:
           type: string
-          example: "https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected"
+          format: uuid
+          example: 12345678-1234-5678-1234-56789abcdef4
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
-                allOf: 
-                  - $ref: '#/components/schemas/Id'
+                allOf:
                   - $ref: '#/components/schemas/Event' 
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse' 
                   - $ref: '#/components/schemas/EventErrorCodes'
 
-  /{id}/event:
+  /{id}/events:
     get:
       tags:
         - NIPC event APIs
@@ -430,46 +352,35 @@ paths:
           type: string
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
-      - name: event
+      - name: instanceId
         in: query
-        description: events that needs to be filtered, multiple values are comma-separated
-        explode: false
-        required: true
+        description: Instance IDs of the events that need to be filtered
+        required: false
         schema:
           type: array
           items:
             type: string
-            example: "https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected"
+            format: uuid
+            example: 12345678-1234-5678-1234-56789abcdef4
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/EventStatusResponseArray'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse' 
                   - $ref: '#/components/schemas/EventErrorCodes'
 
 ### NIPC action APIs
-  /{id}/action/{action}:
-    put:
+  /{id}/actions/{actionName}:
+    post:
       tags:
         - NIPC action APIs
       summary: Perform an action on a device
@@ -485,7 +396,7 @@ paths:
           type: string
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
-      - name: action
+      - name: actionName
         in: path
         description: action that needs to be performed
         required: true
@@ -494,38 +405,69 @@ paths:
           example: "https://example.com/heartrate#/sdfObject/healthsensor/sdfAction/start"
       requestBody:
         content:
-          application/json:
+          application/octet-stream:
             schema:
-              $ref: '#/components/schemas/Value'
-        required: true
+              type: string
+              format: binary
+        required: false
       responses:
-        '200':
-          description: Success
+        '202':
+          description: Accepted, action is being performed
           headers:
-            X-Request-ID:
+            Location:
+              description: Location of the action
               schema:
                 type: string
-              description: Unique Request ID
+                format: uri
+                example: "/{id}/actions/{instanceId}"
+        default:
+          description: Error response
           content:
-            application/json:
-              schema:
-                allOf: 
-                  - $ref: '#/components/schemas/Id'
-                  - $ref: '#/components/schemas/ActionValue'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
-          content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse' 
-                  - $ref: '#/components/schemas/PropertyErrorCodes'   
+                  - $ref: '#/components/schemas/PropertyErrorCodes'
+  /{id}/actions/{instanceId}:
+    get:
+      tags:
+        - NIPC action APIs
+      summary: Get status of an action on a device
+      description: |-
+        Get status of an action on a specific device or a group of devices. Success is action is active, failure if action not active.
+      operationId: GetAction
+      parameters:
+      - name: id
+        in: path
+        description: device id that need to be filtered, group id not allowed
+        required: true
+        schema:
+          type: string
+          format: uuid
+          example: 12345678-1234-5678-1234-56789abcdef4
+      - name: instanceId
+        in: path
+        description: instance id of the action that needs to be checked
+        required: true
+        schema:
+          type: string
+          format: uuid
+          example: 12345678-1234-5678-1234-56789abcdef4
+      responses:
+        '200':
+          description: Success, action is active
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Action'
+        default:
+          description: Error response
+          content:
+            application/problem+json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/FailureResponse' 
+                  - $ref: '#/components/schemas/PropertyErrorCodes'
                   
   /{id}/action/broadcast:
     post:
@@ -553,21 +495,10 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse' 
@@ -601,27 +532,16 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/Id'
                   - $ref: './protocolmaps/ProtocolMap.yaml#/components/schemas/ProtocolMap-ServiceMap'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse' 
@@ -653,27 +573,16 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/Id'
                   - $ref: './protocolmaps/ProtocolMap.yaml#/components/schemas/ProtocolMap-ServiceMap'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse' 
@@ -699,26 +608,15 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/Id'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse' 
@@ -743,27 +641,16 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/Id'
                   - $ref: './protocolmaps/ProtocolMap.yaml#/components/schemas/ProtocolMap-ServiceMap'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse' 
@@ -799,11 +686,6 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
@@ -811,16 +693,10 @@ paths:
                   - $ref: '#/components/schemas/Id'
                   - $ref: '#/components/schemas/Value'
                   - $ref: './protocolmaps/ProtocolMap.yaml#/components/schemas/ProtocolMap-Property'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse' 
@@ -853,11 +729,6 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
@@ -865,16 +736,10 @@ paths:
                   - $ref: '#/components/schemas/Id'
                   - $ref: '#/components/schemas/Value'
                   - $ref: './protocolmaps/ProtocolMap.yaml#/components/schemas/ProtocolMap-Property'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse' 
@@ -899,26 +764,15 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/SdfReference'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse'
@@ -933,11 +787,6 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
@@ -945,16 +794,10 @@ paths:
                 items:
                   allOf:
                     - $ref: '#/components/schemas/SdfReference'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse'
@@ -985,26 +828,15 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/SdfReference'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse'
@@ -1027,26 +859,15 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/SdfReference'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse'
@@ -1069,31 +890,20 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/SdfModel'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse'
 
-  /registration/data-app/{data-app}:
+  /registration/data-app/{dataAppId}:
     post:
       tags:
         - NIPC registration APIs
@@ -1102,7 +912,7 @@ paths:
         Register a dataApp that is able to receive device data. 
       operationId: registerDataApp
       parameters:
-        - name: data-app
+        - name: dataAppId
           in: path
           description: id of the data app that will be registered
           required: true
@@ -1119,26 +929,15 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/DataApp'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse'
@@ -1151,7 +950,7 @@ paths:
         Update registration of a dataApp that is able to receive device data. 
       operationId: UpdateDataApp
       parameters:
-        - name: data-app
+        - name: dataAppId
           in: path
           description: id of the data app that will be updated
           required: true
@@ -1168,26 +967,15 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/DataApp'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse'
@@ -1200,7 +988,7 @@ paths:
         Delete registration of a dataApp that is able to receive device data. 
       operationId: DeleteDataApp
       parameters:
-        - name: data-app
+        - name: dataAppId
           in: path
           description: id of the data app that will be updated
           required: true
@@ -1211,26 +999,15 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/DataApp'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse'
@@ -1243,7 +1020,7 @@ paths:
         Get registrationdetails of a dataApp that is able to receive device data. 
       operationId: GetDataApp
       parameters:
-        - name: data-app
+        - name: dataAppId
           in: path
           description: id of the data app that will be updated
           required: true
@@ -1254,26 +1031,15 @@ paths:
       responses:
         '200':
           description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/DataApp'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
-            application/json:
+            application/problem+json:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse'
@@ -1336,12 +1102,9 @@ components:
 
 ## An array of Property values
     PropertyValueArray:
-      type: object
-      properties:
-        properties:
-          type: array
-          items:
-            $ref: '#/components/schemas/PropertyValue'
+      type: array
+      items:
+        $ref: '#/components/schemas/PropertyValue'
 
 ## Event
     Event:
@@ -1629,15 +1392,32 @@ components:
 
 # responses
 
-## Error 500 application Failure response
-    FailureResponse:
+    SuccessResponse:
       type: object
       properties:
         status:
           type: integer
           format: int32
+          example: 200
+          description: HTTP status code
+
+## Error 500 application Failure response
+    FailureResponse:
+      type: object
+      properties:
+        type:
+          type: string
+          example: https://www.iana.org/assignments/http-problem-types#server-error
+          description: URI to the error type
+        status:
+          type: integer
+          format: int32
           example: 400
           description: HTTP status code
+        title:
+          type: string
+          example: NIPC server error
+          description: Human-readable error title
         detail:
           type: string
           example: Bad request
@@ -1706,30 +1486,22 @@ components:
     
     PropertyValueResponseArrayItem:
       oneOf:
-        - $ref: '#/components/schemas/PropertyValue'
+        - $ref: '#/components/schemas/SuccessResponse'
         - $ref: '#/components/schemas/FailureResponse'
     
     PropertyValueResponseArray:
-      type: object
-      properties:
-        properties:
-          type: array
-          items:
-              $ref: '#/components/schemas/PropertyValueResponseArrayItem'
+      type: array
+      items:
+          $ref: '#/components/schemas/PropertyValueResponseArrayItem'
 
 ## Event operations responses
     EventStatusResponseArrayItem:
-      allOf:
-        - $ref: '#/components/schemas/Id'
-        - $ref: '#/components/schemas/Event' 
       oneOf:
+        - $ref: '#/components/schemas/Event'
         - $ref: '#/components/schemas/FailureResponse'
 
     EventStatusResponseArray:
-      type: object
-      properties:
-        events:
-          type: array
-          items:
-              $ref: '#/components/schemas/EventStatusResponseArrayItem'
+      type: array
+      items:
+          $ref: '#/components/schemas/EventStatusResponseArrayItem'
 

--- a/nipc-openapi/NIPC.yaml
+++ b/nipc-openapi/NIPC.yaml
@@ -1063,7 +1063,7 @@ components:
           format: uuid
           description: A SCIM-generated UUID, can be a device or group
           example: 12345678-1234-5678-1234-56789abcdef4
-          
+
 ## A property
     Property:
       required:

--- a/nipc-openapi/extensions/Extension-Blob.yaml
+++ b/nipc-openapi/extensions/Extension-Blob.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
 openapi: 3.0.3
 info:
   title: Non IP Device Control (NIPC) API write binary blob extension
@@ -9,12 +10,12 @@ info:
   license:
     name: TBD
     url: TBD
-  version: 0.5.1
+  version: 0.5.3
 externalDocs:
   description: NIPC IETF draft
   url: https://datatracker.ietf.org/doc/draft-ietf-asdf-nipc/
 servers:
-  - url: "{gw_host}/nipc/draft-05"
+  - url: "{gw_host}/nipc/draft-07"
     variables:
       gw_host:
         default: localhost
@@ -26,7 +27,7 @@ tags:
 
 paths:
 ### Extensions
-  /{id}/extension/property/{property}/blob:
+  /extensions/{id}/properties/{propertyName}/blob:
     put:
       tags:
         - NIPC API extensions
@@ -43,7 +44,7 @@ paths:
           type: string
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
-      - name: property
+      - name: propertyName
         in: path
         description: property that needs to be filtered
         required: true
@@ -57,33 +58,14 @@ paths:
               $ref: '#/components/schemas/Extension-Blob'
         required: true
       responses:
-        '200':
-          description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
+        '204':
+          description: Success, no content
+        'default':
+          description: Error response
           content:
             application/json:
               schema:
-                allOf: 
-                  - $ref: '../NIPC.yaml#/components/schemas/Id'
-                  - $ref: '../NIPC.yaml#/components/schemas/Property'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '../NIPC.yaml#/components/schemas/FailureResponse' 
-                  - $ref: '../NIPC.yaml#/components/schemas/PropertyErrorCodes'
+                $ref: '../NIPC.yaml#/components/schemas/FailureResponse' 
 
 components:
   schemas:

--- a/nipc-openapi/extensions/Extension-Blob.yaml
+++ b/nipc-openapi/extensions/Extension-Blob.yaml
@@ -38,7 +38,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id is not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string
@@ -46,7 +46,7 @@ paths:
           example: 12345678-1234-5678-1234-56789abcdef4
       - name: propertyName
         in: path
-        description: property that needs to be filtered
+        description: The SDF property name that needs to be written to.
         required: true
         schema:
           type: string

--- a/nipc-openapi/extensions/Extension-Bulk.yaml
+++ b/nipc-openapi/extensions/Extension-Bulk.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
 openapi: 3.0.3
 info:
   title: Non IP Device Control (NIPC) API bulk extension
@@ -9,12 +10,12 @@ info:
   license:
     name: TBD
     url: TBD
-  version: 0.5.1
+  version: 0.5.3
 externalDocs:
   description: NIPC IETF draft
   url: https://datatracker.ietf.org/doc/draft-ietf-asdf-nipc/
 servers:
-  - url: "{gw_host}/nipc/draft-05"
+  - url: "{gw_host}/nipc/draft-07"
     variables:
       gw_host:
         default: localhost
@@ -26,7 +27,7 @@ tags:
 
 paths:
 ### Extensions
-  /{id}/extension/bulk:
+  /extensions/{id}/bulk:
     post:
       tags:
         - NIPC API extensions
@@ -55,15 +56,11 @@ paths:
         '202':
           description: Accepted
           headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
             Location:
               schema:
                 type: string
               description: URL to get the bulk status response
-              example: /12345678-1234-5678-1234-56789abcdef4/extension/bulk/status?requestId=12345678-1234-5678-1234-56789abcdef4
+              example: /extensions/12345678-1234-5678-1234-56789abcdef4/bulk/status?requestId=12345678-1234-5678-1234-56789abcdef4
         '401':
           description: Unauthorized
         '405':
@@ -73,9 +70,7 @@ paths:
           content:
             application/json:
               schema:
-                anyOf:
-                  - $ref: '../NIPC.yaml#/components/schemas/FailureResponse' 
-                  - $ref: '../NIPC.yaml#/components/schemas/PropertyErrorCodes'
+                $ref: '../NIPC.yaml#/components/schemas/FailureResponse'
       callbacks:
         bulkEvent:
           '{$request.body#/callback.url}':
@@ -127,10 +122,6 @@ paths:
         '200':
           description: OK
           headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
@@ -143,7 +134,7 @@ paths:
                 errorBulkResponse:
                   $ref: '#/components/examples/errorBulkResponse'
                 
-  /{id}/extension/bulk/status:
+  /extensions/{id}/bulk/status:
     get:
       tags:
         - NIPC API extensions
@@ -171,15 +162,10 @@ paths:
         '200':
           description: OK
           headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../NIPC.yaml#/components/schemas/Id'
                   - $ref: './Extension-ReadConditional.yaml#/components/schemas/Extension-StatusResponse'
         '303':
           description: See Other
@@ -188,18 +174,16 @@ paths:
               schema:
                 type: string
               description: URL to get the bulk response
-              example: /12345678-1234-5678-1234-56789abcdef4/extension/bulk?requestId=12345678-1234-5678-1234-56789abcdef4
+              example: /extensions/12345678-1234-5678-1234-56789abcdef4/bulk?requestId=12345678-1234-5678-1234-56789abcdef4
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../NIPC.yaml#/components/schemas/Id'
                   - $ref: './Extension-ReadConditional.yaml#/components/schemas/Extension-StatusResponse'
               examples:
                 successExample:
                   summary: Success
                   value:
-                    id: 12345678-1234-5678-1234-56789abcdef4
                     status: COMPLETED
 
 components:
@@ -233,10 +217,10 @@ components:
             path:
               type: string
               enum:
-                - /{id}/property/{property}
-                - /{id}/action/{action}
-                - /{id}/extension/property/{property}/read/conditional
-              example: /12345678-1234-5678-1234-56789abcdef4/property/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
+                - /devices/{id}/properties/{propertyName}
+                - /devices/{id}/actions/{actionName}
+                - /extensions/{id}/properties/{propertyName}/read/conditional
+              example: /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
             data:
               type: object
               oneOf:
@@ -267,20 +251,15 @@ components:
             path:
               type: string
               enum:
-                - /{id}/property/{property}
-                - /{id}/action/{action}
-                - /{id}/extension/property/{property}/read/conditional'
-              example: /12345678-1234-5678-1234-56789abcdef4/property/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
+                - /devices/{id}/properties/{propertyName}
+                - /devices/{id}/actions/{actionName}
+                - /extensions/{id}/properties/{propertyName}/read/conditional
+              example: /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
             response:
               anyOf:
-                - allOf:
-                  - $ref: '../NIPC.yaml#/components/schemas/Id'
-                  - $ref: '../NIPC.yaml#/components/schemas/PropertyValue'
-                - allOf: 
-                  - $ref: '../NIPC.yaml#/components/schemas/Id'
-                  - $ref: '../NIPC.yaml#/components/schemas/ActionValue'
+                - $ref: '../NIPC.yaml#/components/schemas/Value'
+                - $ref: '../NIPC.yaml#/components/schemas/SuccessResponse'
                 - $ref: '../NIPC.yaml#/components/schemas/FailureResponse'
-                - $ref: '../NIPC.yaml#/components/schemas/PropertyErrorCodes'
 
   examples:
     bulkRequest:
@@ -288,16 +267,13 @@ components:
       value:
         operations:
           - method: GET
-            path: >-
-              /12345678-1234-5678-1234-56789abcdef4/property/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
           - method: PUT
-            path: >-
-              /12345678-1234-5678-1234-56789abcdef4/property/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
             data:
               value: dGVzdA==
           - method: POST
-            path: >-
-              /12345678-1234-5678-1234-56789abcdef4/extension/property/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature/read/conditional
+            path: /extensions/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature/read/conditional
             data:
               value: dGVzdA==
               maxRepeat: 5
@@ -307,55 +283,39 @@ components:
       value:
         operations:
           - method: GET
-            path: >-
-              /12345678-1234-5678-1234-56789abcdef4/property/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
             response:
-              id: 12345678-1234-5678-1234-56789abcdef4
-              property: >-
-                https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
               value: dGVzdA==
           - method: PUT
-            path: >-
-              /12345678-1234-5678-1234-56789abcdef4/property/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
             response:
-              id: 12345678-1234-5678-1234-56789abcdef4
-              property: >-
-                https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
-              value: dGVzdA==
+              status: 200
           - method: POST
-            path: >-
-              /12345678-1234-5678-1234-56789abcdef4/extension/property/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature/read/conditional
+            path: /extensions/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature/read/conditional
             response:
-              id: 12345678-1234-5678-1234-56789abcdef4
-              property: >-
-                https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
               value: dGVzdA==
     errorBulkResponse:
       summary: Error Bulk response example
       value:
         operations:
           - method: GET
-            path: >-
-              /12345678-1234-5678-1234-56789abcdef4/property/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
             response:
+              type: https://www.iana.org/assignments/http-problem-types#nipc-property-not-readable
               status: 400
-              detail: Property not readable
-              nipcStatus: 1100
+              title: Property not readable
+              detail: Property https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature is not readable
           - method: PUT
-            path: >-
-              /12345678-1234-5678-1234-56789abcdef4/property/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
             response:
+              type: https://www.iana.org/assignments/http-problem-types#nipc-extension-operation-not-executed
               status: 400
-              detail: >-
-                Operation was not executed since the previous
-                operation failed
-              nipcStatus: 1004
+              title: Operation not executed
+              detail: Operation was not executed since the previous operation failed
           - method: POST
-            path: >-
-              /12345678-1234-5678-1234-56789abcdef4/extension/property/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature/read/conditional
+            path: /extensions/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature/read/conditional
             response:
+              type: https://www.iana.org/assignments/http-problem-types#nipc-extension-operation-not-executed
               status: 400
-              detail: >-
-                Operation was not executed since the previous
-                operation failed
-              nipcStatus: 1004
+              title: Operation not executed
+              detail: Operation was not executed since the previous operation failed

--- a/nipc-openapi/extensions/Extension-Bulk.yaml
+++ b/nipc-openapi/extensions/Extension-Bulk.yaml
@@ -37,7 +37,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id is not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string
@@ -104,7 +104,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id is not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string
@@ -144,7 +144,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id is not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string

--- a/nipc-openapi/extensions/Extension-File.yaml
+++ b/nipc-openapi/extensions/Extension-File.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
 openapi: 3.0.3
 info:
   title: Non IP Device Control (NIPC) API write file extension
@@ -9,12 +10,12 @@ info:
   license:
     name: TBD
     url: TBD
-  version: 0.5.1
+  version: 0.5.3
 externalDocs:
   description: NIPC IETF draft
   url: https://datatracker.ietf.org/doc/draft-ietf-asdf-nipc/
 servers:
-  - url: "{gw_host}/nipc/draft-05"
+  - url: "{gw_host}/nipc/draft-07"
     variables:
       gw_host:
         default: localhost
@@ -26,7 +27,7 @@ tags:
 
 paths:
 ### Extensions
-  /{id}/extension/property/{property}/file:
+  /extensions/{id}/properties/{propertyName}/file:
     put:
       tags:
         - NIPC API extensions
@@ -43,7 +44,7 @@ paths:
           type: string
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
-      - name: property
+      - name: propertyName
         in: path
         description: property that needs to be filtered
         required: true
@@ -57,33 +58,14 @@ paths:
               $ref: '#/components/schemas/Extension-File'
         required: true
       responses:
-        '200':
-          description: Success
-          headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
+        '204':
+          description: Success, no content
+        'default':
+          description: Error response
           content:
             application/json:
               schema:
-                allOf: 
-                  - $ref: '../NIPC.yaml#/components/schemas/Id'
-                  - $ref: '../NIPC.yaml#/components/schemas/Property'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '../NIPC.yaml#/components/schemas/FailureResponse' 
-                  - $ref: '../NIPC.yaml#/components/schemas/PropertyErrorCodes'
+                $ref: '../NIPC.yaml#/components/schemas/FailureResponse' 
 
 components:
   schemas:

--- a/nipc-openapi/extensions/Extension-File.yaml
+++ b/nipc-openapi/extensions/Extension-File.yaml
@@ -38,7 +38,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id is not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string
@@ -46,7 +46,7 @@ paths:
           example: 12345678-1234-5678-1234-56789abcdef4
       - name: propertyName
         in: path
-        description: property that needs to be filtered
+        description: The SDF property name that needs to be written to.
         required: true
         schema:
           type: string

--- a/nipc-openapi/extensions/Extension-Firmware.yaml
+++ b/nipc-openapi/extensions/Extension-Firmware.yaml
@@ -38,7 +38,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id is not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string
@@ -57,10 +57,6 @@ paths:
         '202':
           description: Accepted
           headers:
-            X-Request-ID:
-              schema:
-                type: integer
-              description: Unique Request ID
             Location:
               schema:
                 type: string
@@ -109,7 +105,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id is not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string
@@ -159,7 +155,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id is not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string

--- a/nipc-openapi/extensions/Extension-Firmware.yaml
+++ b/nipc-openapi/extensions/Extension-Firmware.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
 openapi: 3.0.3
 info:
   title: Non IP Device Control (NIPC) API firmware upgrade extension
@@ -9,12 +10,12 @@ info:
   license:
     name: TBD
     url: TBD
-  version: 0.5.1
+  version: 0.5.3
 externalDocs:
   description: NIPC IETF draft
   url: https://datatracker.ietf.org/doc/draft-ietf-asdf-nipc/
 servers:
-  - url: "{gw_host}/nipc/draft-05"
+  - url: "{gw_host}/nipc/draft-07"
     variables:
       gw_host:
         default: localhost
@@ -26,7 +27,7 @@ tags:
 
 paths:
 ### Extensions
-  /{id}/extension/firmware:
+  /extensions/{id}/firmware:
     put:
       tags:
         - NIPC API extensions
@@ -65,14 +66,8 @@ paths:
                 type: string
               description: Location of the resource
               example: /12345678-1234-5678-1234-56789abcdef4/extension/firmware/status?requestId=12345678-1234-5678-1234-56789abcdef4
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        default:
+          description: Error response
           content:
             application/json:
               schema:
@@ -131,10 +126,6 @@ paths:
         '200':
           description: OK
           headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
             Location:
               schema:
                 type: string
@@ -157,7 +148,7 @@ paths:
                 allOf:
                   - $ref: '../NIPC.yaml#/components/schemas/FailureResponse'
                   - $ref: '#/components/schemas/ExtensionErrorCodes'
-  /{id}/extension/firmware/status:
+  /extensions/{id}/firmware/status:
     get:
       tags:
         - NIPC API extensions
@@ -185,10 +176,6 @@ paths:
         '200':
           description: Success
           headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
@@ -238,8 +225,3 @@ components:
           enum:
             - 1600 # Firmware rollback
             - 1601 # Firmware update failed
-
-
-
-
-

--- a/nipc-openapi/extensions/Extension-Property.yaml
+++ b/nipc-openapi/extensions/Extension-Property.yaml
@@ -1,0 +1,164 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+openapi: 3.0.3
+info:
+  title: Non IP Device Control (NIPC) API read conditional extension
+  description: |-
+    Non IP Device Control (NIPC) API read conditional extension
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: bbrinckm@cisco.com
+  license:
+    name: TBD
+    url: TBD
+  version: 0.5.3
+externalDocs:
+  description: NIPC IETF draft
+  url: https://datatracker.ietf.org/doc/draft-ietf-asdf-nipc/
+servers:
+  - url: "{gw_host}/nipc/draft-07"
+    variables:
+      gw_host:
+        default: localhost
+        description: Gateway Host
+tags:
+  - name:  NIPC API extensions
+    description: |-
+      APIs that simplify application interaction by implementing one or more basic APIs into a single API call.
+
+paths:
+### Extensions
+  /extensions/{id}/manage/transmit:
+    post:
+      tags:
+        - NIPC API extensions
+      summary: Broadcast to a device
+      description: |-
+        Broadcast a payload to a device. The broadcast is performed on the AP where the device was last seen
+      operationId: ActionBroadcast
+      parameters:
+        - name: id
+          in: path
+          description: device id that need to be filtered, group id not allowed
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 12345678-1234-5678-1234-56789abcdef4
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Transmit'
+        required: true
+      responses:
+        '200':
+          description: Success
+        default:
+          description: Error response
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../NIPC.yaml#/components/schemas/FailureResponse'
+   
+  /extensions/{id}/action/property/write:
+    post:
+      tags:
+        - NIPC API extensions
+      summary: Write a value to an property using protocol mapping
+      description: |-
+        Write a value to an unregistered property, embedding property protocol mapping in the API, this does not require
+        property registration. You cannot write to a group id.
+      operationId: ActionPropWrite
+      parameters:
+        - name: id
+          in: path
+          description: device id that need to be filtered, group id not allowed
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 12345678-1234-5678-1234-56789abcdef4
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../NIPC.yaml#/components/schemas/Value' 
+                - $ref: '../protocolmaps/ProtocolMap.yaml#/components/schemas/ProtocolMap-Property'
+        required: true
+      responses:
+        '204':
+          description: Success, no content
+        default:
+          description: Error response
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../NIPC.yaml#/components/schemas/FailureResponse'
+                
+  /extensions/{id}/action/property/read:
+    post:
+      tags:
+        - NIPC API extensions
+      summary: Read a value to an property using protocol mapping
+      description: |-
+        Read a value from an unregistered property, embedding property protocol mapping in the API, this does not require
+        property registration. You cannot read from a group id.
+      operationId: ActionPropRead
+      parameters:
+        - name: id
+          in: path
+          description: device id that need to be filtered, group id not allowed
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 12345678-1234-5678-1234-56789abcdef4
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '../protocolmaps/ProtocolMap.yaml#/components/schemas/ProtocolMap-Property'
+        required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf: 
+                  - $ref: '../NIPC.yaml#/components/schemas/Value'
+        default:
+          description: Error response
+          content:
+            application/problem+json:
+              schema:
+                $ref: '../NIPC.yaml#/components/schemas/FailureResponse'
+
+components:
+  schemas:
+    Transmit:
+      allOf:
+        - $ref: '../protocolmaps/ProtocolMap.yaml#/components/schemas/ProtocolMap-Broadcast'
+      required:
+        - cycle
+      type: object
+      properties:
+        cycle:
+          type: string
+          example: single
+          enum:
+            - single
+            - repeat
+        # transmit time in ms
+        transmitTime:
+          type: integer
+          example: 3000
+        # interval between transmits in ms
+        transmitInterval:
+          type: integer
+          example: 500
+        payload:
+          type: string
+          format: byte
+          example: AgEaAgoMFv9MABAHch9BsDkgeA==

--- a/nipc-openapi/extensions/Extension-Property.yaml
+++ b/nipc-openapi/extensions/Extension-Property.yaml
@@ -60,7 +60,7 @@ paths:
               schema:
                 $ref: '../NIPC.yaml#/components/schemas/FailureResponse'
    
-  /extensions/{id}/action/property/write:
+  /extensions/{id}/properties/write:
     post:
       tags:
         - NIPC API extensions
@@ -96,7 +96,7 @@ paths:
               schema:
                 $ref: '../NIPC.yaml#/components/schemas/FailureResponse'
                 
-  /extensions/{id}/action/property/read:
+  /extensions/{id}/properties/read:
     post:
       tags:
         - NIPC API extensions

--- a/nipc-openapi/extensions/Extension-Property.yaml
+++ b/nipc-openapi/extensions/Extension-Property.yaml
@@ -38,7 +38,7 @@ paths:
       parameters:
         - name: id
           in: path
-          description: device id that need to be filtered, group id not allowed
+          description: The ID of the device. Group ID is not allowed.
           required: true
           schema:
             type: string
@@ -72,7 +72,7 @@ paths:
       parameters:
         - name: id
           in: path
-          description: device id that need to be filtered, group id not allowed
+          description: The ID of the device. Group ID is not allowed.
           required: true
           schema:
             type: string
@@ -108,7 +108,7 @@ paths:
       parameters:
         - name: id
           in: path
-          description: device id that need to be filtered, group id not allowed
+          description: The ID of the device. Group ID is not allowed.
           required: true
           schema:
             type: string

--- a/nipc-openapi/extensions/Extension-ReadConditional.yaml
+++ b/nipc-openapi/extensions/Extension-ReadConditional.yaml
@@ -37,7 +37,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id is not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string
@@ -45,7 +45,7 @@ paths:
           example: 12345678-1234-5678-1234-56789abcdef4
       - name: propertyName
         in: path
-        description: property that needs to be filtered
+        description: The SDF property name that needs to be read conditionally.
         required: true
         schema:
           type: string
@@ -117,7 +117,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id is not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string
@@ -125,7 +125,7 @@ paths:
           example: 12345678-1234-5678-1234-56789abcdef4
       - name: propertyName
         in: path
-        description: property that needs to be filtered
+        description: The SDF property name that needs to be read conditionally.
         required: true
         schema:
           type: string
@@ -169,7 +169,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: device id that need to be filtered, group id is not allowed
+        description: The ID of the device. Group ID is not allowed.
         required: true
         schema:
           type: string
@@ -177,7 +177,7 @@ paths:
           example: 12345678-1234-5678-1234-56789abcdef4
       - name: propertyName
         in: path
-        description: property that needs to be filtered
+        description: The SDF property name that needs to be read conditionally.
         required: true
         schema:
           type: string

--- a/nipc-openapi/extensions/Extension-ReadConditional.yaml
+++ b/nipc-openapi/extensions/Extension-ReadConditional.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
 openapi: 3.0.3
 info:
   title: Non IP Device Control (NIPC) API read conditional extension
@@ -9,12 +10,12 @@ info:
   license:
     name: TBD
     url: TBD
-  version: 0.5.1
+  version: 0.5.3
 externalDocs:
   description: NIPC IETF draft
   url: https://datatracker.ietf.org/doc/draft-ietf-asdf-nipc/
 servers:
-  - url: "{gw_host}/nipc/draft-05"
+  - url: "{gw_host}/nipc/draft-07"
     variables:
       gw_host:
         default: localhost
@@ -26,7 +27,7 @@ tags:
 
 paths:
 ### Extensions
-  /{id}/extension/property/{property}/read/conditional:
+  /extensions/{id}/properties/{propertyName}/read/conditional:
     post:
       tags:
         - NIPC API extensions
@@ -42,7 +43,7 @@ paths:
           type: string
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
-      - name: property
+      - name: propertyName
         in: path
         description: property that needs to be filtered
         required: true
@@ -59,10 +60,6 @@ paths:
         '202':
           description: Accepted
           headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
             Location:
               schema:
                 type: string
@@ -72,20 +69,12 @@ paths:
               schema:
                 type: integer
               description: Time in seconds to wait before retrying
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
+        'default':
+          description: Error response
           content:
             application/json:
               schema:
-                anyOf:
-                  - $ref: '../NIPC.yaml#/components/schemas/FailureResponse' 
-                  - $ref: '../NIPC.yaml#/components/schemas/PropertyErrorCodes'
+                $ref: '../NIPC.yaml#/components/schemas/FailureResponse'
       callbacks:
         callbackEvent:
           "{$request.body#/callback.url}":
@@ -99,7 +88,6 @@ paths:
                           - $ref: '../NIPC.yaml#/components/schemas/Id'
                           - $ref: '../NIPC.yaml#/components/schemas/PropertyValue'
                         - $ref: '../NIPC.yaml#/components/schemas/FailureResponse'
-                        - $ref: '../NIPC.yaml#/components/schemas/PropertyErrorCodes'
                     examples:
                       successExample:
                         summary: Success
@@ -135,7 +123,7 @@ paths:
           type: string
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
-      - name: property
+      - name: propertyName
         in: path
         description: property that needs to be filtered
         required: true
@@ -154,31 +142,24 @@ paths:
         '200':
           description: Success
           headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../NIPC.yaml#/components/schemas/Id'
-                  - $ref: '../NIPC.yaml#/components/schemas/PropertyValue'
-        '400':
-          description: Bad request
-        '401':
-          description: Unauthorized
-        '405':
-          description: Invalid request
-        '500':
-          description: Server-side failure
-          content:
-            application/json:
+                  - $ref: '../NIPC.yaml#/components/schemas/Value'
+            application/octet-stream:
               schema:
-                anyOf:
-                  - $ref: '../NIPC.yaml#/components/schemas/FailureResponse' 
-                  - $ref: '../NIPC.yaml#/components/schemas/PropertyErrorCodes'
-  /{id}/extension/property/{property}/read/conditional/status:
+                type: string
+                format: binary
+              description: Binary data of the property value
+        default:
+          description: Error response
+          content:
+            application/problem+json:
+              schema:
+                allOf:
+                  - $ref: '../NIPC.yaml#/components/schemas/FailureResponse'
+  /extensions/{id}/properties/{propertyName}/read/conditional/status:
     get:
       tags:
         - NIPC API extensions
@@ -194,7 +175,7 @@ paths:
           type: string
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
-      - name: property
+      - name: propertyName
         in: path
         description: property that needs to be filtered
         required: true
@@ -213,15 +194,10 @@ paths:
         '200':
           description: OK
           headers:
-            X-Request-ID:
-              schema:
-                type: string
-              description: Unique Request ID
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../NIPC.yaml#/components/schemas/Id'
                   - $ref: '#/components/schemas/Extension-StatusResponse'
         '303':
           description: See Other
@@ -235,7 +211,6 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../NIPC.yaml#/components/schemas/Id'
                   - $ref: '#/components/schemas/Extension-StatusResponse'
               examples:
                 successExample:

--- a/nipc-openapi/protocolmaps/ProtocolMap-BLE.yaml
+++ b/nipc-openapi/protocolmaps/ProtocolMap-BLE.yaml
@@ -9,7 +9,7 @@ info:
   license:
     name: TBD
     url: TBD
-  version: 0.5.0
+  version: 0.5.3
 externalDocs:
   description: NIPC IETF draft
   url: https://datatracker.ietf.org/doc/draft-ietf-asdf-nipc/

--- a/nipc-openapi/protocolmaps/ProtocolMap-Zigbee.yaml
+++ b/nipc-openapi/protocolmaps/ProtocolMap-Zigbee.yaml
@@ -9,7 +9,7 @@ info:
   license:
     name: TBD
     url: TBD
-  version: 0.5.0
+  version: 0.5.3
 externalDocs:
   description: NIPC IETF draft
   url: https://datatracker.ietf.org/doc/draft-ietf-asdf-nipc/

--- a/nipc-openapi/protocolmaps/ProtocolMap.yaml
+++ b/nipc-openapi/protocolmaps/ProtocolMap.yaml
@@ -9,7 +9,7 @@ info:
   license:
     name: TBD
     url: TBD
-  version: 0.5.0
+  version: 0.5.3
 externalDocs:
   description: NIPC IETF draft
   url: https://datatracker.ietf.org/doc/draft-ietf-asdf-nipc/


### PR DESCRIPTION
- Updated API paths to use RESTful resource naming conventions:
  - `/{id}/property/{property}` → `/devices/{id}/properties/{propertyName}`
  - `/{id}/event/{event}` → `/devices/{id}/events/{eventName}`
  - `/{id}/action/{action}` → `/devices/{id}/actions/{actionName}`
  - `/{id}/action/connection` → `/devices/{id}/manage/connection`
- Added group operations as a separate endpoint:
     - `POST /groups/{id}/events/{eventName}` - Enable event on group
     - `DELETE /groups/{id}/events/{instanceId}` - Disable event on group
     - `GET /groups/{id}/events/{instanceId}` - Get group event status
     - `GET /groups/{id}/events` - Get multiple group events status
- Migrated from custom error format to RFC 9457 Problem Details:
  - Removed `nipcStatus` field and numeric error codes
  - Added `type` field with URI-based error identifiers
  - Added `title` field for brief error summaries
- Updated status codes for better HTTP compliance:
  - Actions now return `202 Accepted` with Location header for status tracking
  - Property writes return `204 No Content` instead of echoing the written data
- Simplified response formats by removing redundant data:
  - Property read responses no longer include `id` and `property` fields
  - Event responses use instance-based tracking with Location headers
  - Removed `X-Request-ID` headers from examples
- Events now use instance-based management:
  - Event enable operations return `201 Created` with Location header
  - Location header contains unique instance ID for tracking
  - Event disable uses instance ID instead of event name
  - Support for multiple instances of the same event type
- Actions now follow asynchronous pattern:
  - `POST /devices/{id}/actions/{actionName}` returns `202 Accepted`
  - Location header points to action instance for status checking
  - `GET /devices/{id}/actions/{instanceId}` checks action status
  - Status responses include completion state (e.g., "IN_PROGRESS", "COMPLETED")
- SDF model registration response format changed:
  - Now returns array format: `[{"sdfName": "..."}]` instead of single object
- Multi-property operations now use array format:
  - Request/response bodies are direct arrays instead of objects with `properties` field
  - Simplified structure: `[{"property": "...", "value": "..."}]`
- Moved embedded protocol mapping APIs to extensions:
  - `POST /{id}/action/property/write` → `/extensions/{id}/properties/write`
  - `POST /{id}/action/property/read` → `/extensions/{id}/properties/read`
  - `POST /{id}/action/broadcast` → `/extensions/{id}/manage/transmit`
- Fixed API path reference in connection management documentation:
  - `/{id}/action/connection` → `/devices/{id}/manage/connection`