### PR TITLE
Draft changes to address the issue in #103

### DIFF
--- a/draft-ietf-asdf-nipc.mkd
+++ b/draft-ietf-asdf-nipc.mkd
@@ -380,10 +380,10 @@ Gateway will leverage the exissting connection and will also not tear the
 connection down after the operation completes. The app will have to explicitly
 close the connection. 
 
-### Action APIs with embedded protocol mapping
+### Management APIs
 
-Action APIs with embedded protocol mapping are APIs that perform actions on
-devices, but do not use registered affordances. These APIs have embedded
+Management APIs are APIs that perform device connection management and
+protocol-specific operations, but do not use registered affordances. These APIs have embedded
 protocol mappings. They require explicit connection management.
 
 ### Extensions {#extensions}
@@ -635,14 +635,14 @@ where-
 
 ### Get an sdf model
 
-Method: `GET /registration/model/{sdfName}`
+Method: `GET /registration/model`
 
 Description: Gets an sdf model registered with the gateway
 
-Parameters: 
+Query Parameters: 
 
  - sdfName: the reference to the top-level sdfThing or sdfObject 
-    in the SDF model. This is a percent-encoded URL string.
+    in the SDF model.
 
 Response:
 
@@ -651,14 +651,14 @@ The sdf model is returned in JSON format, similar to the example in
 
 ### Delete an sdf model
 
-Method: `DELETE /registration/model/{sdfName}`
+Method: `DELETE /registration/model`
 
 Description: Deletes an sdf model registered with the gateway
 
-Parameters: 
+Query Parameters: 
 
  - sdfName: the reference to the top-level sdfThing or sdfObject 
-    in the SDF model. This is a percent-encoded URL string.
+    in the SDF model.
 
 Response:
 
@@ -678,14 +678,14 @@ where-
 
 ### Update an sdf model
 
-Method: `PUT /registration/model/{sdfName}`
+Method: `PUT /registration/model`
 
 Description: Updates an sdf model registered with the gateway
 
-Parameters: 
+Query Parameters: 
 
  - sdfName: the reference to the top-level sdfThing or sdfObject 
-    in the SDF model. This is a percent-encoded URL string.
+    in the SDF model.
 
 Request Body:
 
@@ -717,11 +717,11 @@ that is registered with the SCIM server. The endpoint app is defined in
 
 ### Register a data application
 
-Method: `POST /registration/data-app/{dataAppId}`
+Method: `POST /registration/data-app`
 
 Description: Registers a data application with the gateway
 
-Parameters: 
+Query Parameters: 
 
  - dataAppId: the id of the data application
 
@@ -798,11 +798,11 @@ If successful, the response will be identical to the request body.
 
 ### Update a data application
 
-Method: `PUT /registration/data-app/{dataAppId}`
+Method: `PUT /registration/data-app`
 
 Description: Updates a data application with the gateway
 
-Parameters: 
+Query Parameters: 
 
  - dataAppId: the id of the data application
 
@@ -814,11 +814,11 @@ If successful, the response will be identical to the request body.
 
 ### Get a data application
 
-Method: `GET /registration/data-app/{dataAppId}`
+Method: `GET /registration/data-app`
 
 Description: Gets a data application registered with the gateway
 
-Parameters: 
+Query Parameters: 
 
  - dataAppId: the id of the data application
 
@@ -829,11 +829,11 @@ application API.
 
 ### Delete a data application
 
-Method: `DELETE /registration/data-app/{dataAppId}`
+Method: `DELETE /registration/data-app`
 
 Description: Deletes a data application registered with the gateway
 
-Parameters: 
+Query Parameters: 
 
  - dataAppId: the id of the data application
 
@@ -855,9 +855,9 @@ The NIPC APIs are divided into 3 categories:
    reporting on devices.
  - NIPC Action APIs: These APIs allow applications to perform actions on
    devices.
- - NIPC Action APIs with embedded protocol mapping: These APIs allow
-   applications to perform actions on devices, but do not use registered
-   properties, events or actions.
+ - NIPC Management APIs: These APIs allow
+   applications to manage device connections and perform protocol-specific
+   operations.
 
 An SDF model must be registered for the device in order to use these NIPC
 Property, Event and Action APIs. The SDF model can be a top-level sdfThing with
@@ -869,7 +869,6 @@ as described in {{Section 4 of I-D.ietf-asdf-sdf}}.
 
 The SDF global name will be used against the registered SDF model to 
 determine the protocol-specific protocolMap that the NIPC API will operate on. 
-The global name must be percent-encoded to be used in the URL as per {{!RFC3986}}.
 
 ## NIPC Property APIs
 
@@ -889,63 +888,6 @@ the format shown in the examples above, with binary data encoded as
 base64 in the "value" field. 
 For other content types, the data is transmitted according to the 
 specific format requirements of that media type.
-
-### Write a value
-
-Method: `PUT /devices/{id}/properties/{propertyName}`
-
-Description: Writes a value to a property on a device
-
-Parameters: 
-
- - id: the id of the device
- - propertyName: the property to write to
-
-Request Body:
-
-the binary data to write to the property (using `application/octet-stream`)
-
-Response:
-
-HTTP status code 204 No Content is returned for successful writes.
-
-A failure will generate a standard failed response. Please refer to {{failure}}
-definition of failed response.
-
-### Read a value
-
-Method: `GET /devices/{id}/properties/{propertyName}`
-
-Description: Reads a value from a property on a device
-
-Parameters: 
-
- - id: the id of the device
- - propertyName: the property to read from
-
-Response:
-
-The response will be the binary data read from the property. 
-
-If the Accept header is set to `application/octet-stream`, the response body
-will contain the raw binary data.
-
-Example of a read property response if the Accept header is set to
-`application/json`:
-
-~~~~~
-{
-  "value": "dGVzdA=="
-}
-~~~~~
-{:json #exreresp title="Example read property response"}
-
-where-
-
- - "value" is the bytes that were read in base64 encoding
-
-A failure will generate a standard failed response. Please refer to {{failure}}
-definition of failed response.
 
 ### Write multiple values
 
@@ -1083,13 +1025,16 @@ used as the MQTT topic instead.
 
 ### Enable event reporting
 
-Method: `POST /devices/{id}/events/{eventName}`
+Method: `POST /devices/{id}/events`
 
 Description: Enables an event on a specific device
 
 Parameters: 
 
  - id: the id of the device
+
+Query Parameters:
+
  - eventName: the event to enable
 
 The eventName is a URL encoded string that is the absolute URI that is a global
@@ -1103,7 +1048,7 @@ Example of a successful response:
 
 ~~~~~
 HTTP/1.1 201 Created
-Location: /devices/12345678-1234-5678-1234-56789abcdef4/events/87654321-4321-8765-4321-fedcba9876543
+Location: /devices/12345678-1234-5678-1234-56789abcdef4/events?instanceId=87654321-4321-8765-4321-fedcba9876543
 ~~~~~
 
 The Location header contains the URI for the created event instance, which can be used to check status or disable the event.
@@ -1113,13 +1058,16 @@ definition of failed response.
 
 ### Disable event reporting
 
-Method: `DELETE /devices/{id}/events/{instanceId}`
+Method: `DELETE /devices/{id}/events`
 
 Description: Disables an event on a specific device
 
 Parameters:
 
   - id: the id of the device or group of devices
+
+Query Parameters:
+
   - instanceId: the instance ID of the event to disable (obtained from the Location header when the event was enabled)
 
 Response:
@@ -1135,13 +1083,16 @@ definition of failed response.
 
 ### Get event status
 
-Method: `GET /devices/{id}/events/{instanceId}`
+Method: `GET /devices/{id}/events`
 
 Description: Get the status of an event on a specific device
 
 Parameters:
 
   - id: the id of the device or group of devices
+
+Query Parameters:
+
   - instanceId: the instance ID of the event to query
 
 Response:
@@ -1198,13 +1149,16 @@ definition of failed response.
 
 ### Enable event reporting on a group of devices
 
-Method: `POST /groups/{id}/events/{eventName}`
+Method: `POST /groups/{id}/events`
 
 Description: Enables an event on a group of devices
 
 Parameters: 
 
  - id: the id of the group of devices
+
+Query Parameters:
+
  - eventName: the event to enable
 
 The eventName is a URL encoded string that is the absolute URI that is a global
@@ -1218,7 +1172,7 @@ Example of a successful response:
 
 ~~~~~
 HTTP/1.1 201 Created
-Location: /groups/12345678-1234-5678-1234-56789abcdef4/events/87654321-4321-8765-4321-fedcba9876543
+Location: /groups/12345678-1234-5678-1234-56789abcdef4/events?instanceId=87654321-4321-8765-4321-fedcba9876543
 ~~~~~
 
 The Location header contains the URI for the created event instance, which can be used to check status or disable the event.
@@ -1228,13 +1182,16 @@ definition of failed response.
 
 ### Disable event reporting on a group of devices
 
-Method: `DELETE /groups/{id}/events/{instanceId}`
+Method: `DELETE /groups/{id}/events`
 
 Description: Disables an event on a group of devices
 
 Parameters:
 
   - id: the id of the group of devices
+
+Query Parameters:
+
   - instanceId: the instance ID of the event to disable (obtained from the Location header when the event was enabled)
 
 Response:
@@ -1250,13 +1207,16 @@ definition of failed response.
 
 ### Get event status on a group of devices
 
-Method: `GET /groups/{id}/events/{instanceId}`
+Method: `GET /groups/{id}/events`
 
 Description: Get the status of an event on a group of devices
 
 Parameters:
 
  - id: the id of the group of devices
+
+Query Parameters:
+
  - instanceId: the instance ID of the event to check
 
 Response:
@@ -1321,13 +1281,16 @@ without modifying it.
 
 ### Perform an action
 
-Method: `POST /devices/{id}/actions/{actionName}`
+Method: `POST /devices/{id}/actions`
 
 Description: Perform an action on a specific device
 
 Parameters:
 
   - id: the id of the device
+
+Query Parameters:
+
   - actionName: the action to perform
 
 Request Body:
@@ -1344,20 +1307,23 @@ Example of a successful response:
 
 ~~~~~
 HTTP/1.1 202 Accepted
-Location: /devices/12345678-1234-5678-1234-56789abcdef4/actions/87654321-4321-8765-4321-fedcba9876543
+Location: /devices/12345678-1234-5678-1234-56789abcdef4/actions?instanceId=87654321-4321-8765-4321-fedcba9876543
 ~~~~~
 
 The Location header contains the URI for the action instance, which can be used to check the action status.
 
 ### Check action status
 
-Method: `GET /devices/{id}/actions/{instanceId}`
+Method: `GET /devices/{id}/actions`
 
 Description: Check the status of an action on a specific device
 
 Parameters:
 
   - id: the id of the device
+
+Query Parameters:
+
   - instanceId: the instance ID of the action (obtained from the Location header)
 
 Response:
@@ -1376,9 +1342,9 @@ where "status" indicates the current state of the action (e.g., "IN_PROGRESS" or
 A failure will generate a standard failed response. Please refer to {{failure}}
 definition of failed response.
 
-## NIPC Action APIs with embedded protocol mapping
+## NIPC Management APIs
 
-These APIs allow applications to perform actions on devices, but do not use
+These APIs allow applications to manage device connections, but do not use
 registered properties, events or actions. These APIs do not perform an implicit
 connection, so a connection must be established before calling these APIs.
 
@@ -1950,26 +1916,44 @@ The sequence of operations for this are:
   - Read a property from the BLE device
 
     ~~~~~
-    GET /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Fdevice_name
-    Accept: application/octet-stream
+    GET /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/device_name
+    Accept: application/json
     Host: localhost
     
     HTTP/1.1 200 OK
-    content-type: application/octet-stream
+    content-type: application/json
     
-    ... (binary data)
+    [
+      {
+        "property": "https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/device_name",
+        "value": "dGVzdA=="
+      }
+    ]
     ~~~~~
  
   - Write to a property on the BLE device
 
     ~~~~~
-    PUT /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Fdevice_name
-    Content-Type: application/octet-stream
+    PUT /devices/12345678-1234-5678-1234-56789abcdef4/properties
+    Content-Type: application/json
     Host: localhost
     
-    ... (binary data)
+    [
+      {
+        "property": "https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/device_name",
+        "value": "dGVzdA=="
+      }
+    ]
     
-    HTTP/1.1 204 No Content
+    HTTP/1.1 200 OK
+    content-type: application/json
+    
+    [
+      {
+        "property": "https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/device_name",
+        "value": "dGVzdA=="
+      }
+    ]
     ~~~~~
 
 ## Enabling an Event
@@ -2004,7 +1988,7 @@ The sequence of operations for this are:
   - Register the data app with the event 
 
     ~~~~~
-    POST /registration/data-app/23456789-1234-5678-1234-56789abcdef4
+    POST /registration/data-app?dataAppId=23456789-1234-5678-1234-56789abcdef4
     Content-Type: application/json
     Accept: application/json
     Host: localhost
@@ -2030,18 +2014,18 @@ The sequence of operations for this are:
   - Enable the advertisement event
 
     ~~~~
-    POST /devices/12345678-1234-5678-1234-56789abcdef4/events/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfEvent%2FisPresent
+    POST /devices/12345678-1234-5678-1234-56789abcdef4/events?eventName=https://example.com/thermometer#/sdfThing/thermometer/sdfEvent/isPresent
     Host: localhost
     Content-Length: 0
     
-    HTTP/1.1 201 OK
-    Location: /devices/12345678-1234-5678-1234-56789abcdef4/events/87654321-4321-8765-4321-fedcba9876543
+    HTTP/1.1 201 Created
+    Location: /devices/12345678-1234-5678-1234-56789abcdef4/events?instanceId=87654321-4321-8765-4321-fedcba9876543
     ~~~~
 
   - Check the status of the event
 
     ~~~~~
-    GET /devices/12345678-1234-5678-1234-56789abcdef4/events/87654321-4321-8765-4321-fedcba9876543
+    GET /devices/12345678-1234-5678-1234-56789abcdef4/events?instanceId=87654321-4321-8765-4321-fedcba9876543
     Host: localhost
     
     HTTP/1.1 200 OK

--- a/draft-ietf-asdf-nipc.mkd
+++ b/draft-ietf-asdf-nipc.mkd
@@ -1,7 +1,7 @@
 ---
 title: An Application Layer Interface for Non-IP device control (NIPC)
 abbrev: NIPC
-docname: draft-ietf-asdf-nipc-07
+docname: draft-ietf-asdf-nipc-08
 submissionType: IETF
 category: std
 
@@ -1916,7 +1916,7 @@ The sequence of operations for this are:
   - Read a property from the BLE device
 
     ~~~~~
-    GET /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/device_name
+    GET /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer%23/sdfThing/thermometer/sdfProperty/device_name
     Accept: application/json
     Host: localhost
     
@@ -2016,7 +2016,7 @@ The sequence of operations for this are:
   - Enable the advertisement event
 
     ~~~~
-    POST /devices/12345678-1234-5678-1234-56789abcdef4/events?eventName=https://example.com/thermometer#/sdfThing/thermometer/sdfEvent/isPresent
+    POST /devices/12345678-1234-5678-1234-56789abcdef4/events?eventName=https://example.com/thermometer%23/sdfThing/thermometer/sdfEvent/isPresent
     Host: localhost
     Content-Length: 0
     

--- a/draft-ietf-asdf-nipc.mkd
+++ b/draft-ietf-asdf-nipc.mkd
@@ -1978,9 +1978,11 @@ The sequence of operations for this are:
     HTTP/1.1 200 OK
     content-type: application/json
 
-    {
-      "sdfName": "https://example.com/thermometer#/sdfThing/thermometer"
-    }
+    [
+      {
+        "sdfName": "https://example.com/thermometer#/sdfThing/thermometer"
+      }
+    ]
     ~~~~~
 
     Request Body: JSON object with the SDF model, from {{thermometer-sdf}}

--- a/nipc-openapi/NIPC.yaml
+++ b/nipc-openapi/NIPC.yaml
@@ -104,6 +104,7 @@ paths:
         in: query
         description: Properties to be read
         required: true
+        allowReserved: true
         schema:
           type: array
           items:
@@ -147,6 +148,7 @@ paths:
         in: query
         description: event that needs to be enabled
         required: true
+        allowReserved: true
         schema:
           type: string
           example: "https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected"
@@ -262,6 +264,7 @@ paths:
         in: query
         description: event that needs to be enabled
         required: true
+        allowReserved: true
         schema:
           type: string
           example: "https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected"
@@ -376,6 +379,7 @@ paths:
         in: query
         description: action that needs to be performed
         required: true
+        allowReserved: true
         schema:
           type: string
           example: "https://example.com/heartrate#/sdfObject/healthsensor/sdfAction/start"
@@ -628,6 +632,7 @@ paths:
           in: query
           description: sdfName can be a reference to an sdfThing or sdfObject
           required: false
+          allowReserved: true
           schema:
             type: string
             example: "https://example.com/heartrate#/sdfObject/healthsensor"
@@ -657,6 +662,7 @@ paths:
           in: query
           description: sdfName can be a reference to an sdfThing or sdfObject
           required: true
+          allowReserved: true
           schema:
             type: string
             example: "https://example.com/heartrate#/sdfObject/healthsensor"

--- a/nipc-openapi/NIPC.yaml
+++ b/nipc-openapi/NIPC.yaml
@@ -46,91 +46,6 @@ tags:
 
 paths:
 ### NIPC Property APIs
-  /devices/{id}/properties/{propertyName}:
-    put:
-      tags:
-        - NIPC property APIs
-      summary: Write a value to a property on a device
-      description: |-
-        Write a value to a property on a device. If the underlying protocol requires a connection to be set up, this API call will perform the necessary connection management. If a connection is already active for this device, the existing connection will be leveraged without modifying it. Id cannot be a group-id.
-      operationId: UpdateProperty
-      parameters:
-      - name: id
-        in: path
-        description: The ID of the device. Group ID is not allowed.
-        required: true
-        schema:
-          type: string
-          format: uuid
-          example: 12345678-1234-5678-1234-56789abcdef4
-      - name: propertyName
-        in: path
-        description: the property to write to
-        required: true
-        schema:
-          type: string
-          example: "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/temperature"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Value'
-          application/octet-stream:
-            schema:
-              type: string
-              format: binary
-        required: true
-      responses:
-        '204':
-          description: Success, no content
-        default:
-          description: Error response
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-
-    get:
-      tags:
-        - NIPC property APIs
-      summary: Read a value from a property on a device
-      description: |-
-        Read a value to a property on a device. If the underlying protocol requires a connection to be set up, this API call will perform the necessary connection management. If a connection is already active for this device, the existing connection will be leveraged without modifying it. Id cannot be a group-id.
-      operationId: GetProperty
-      parameters:
-      - name: id
-        in: path
-        description: The ID of the device. Group ID is not allowed.
-        required: true
-        schema:
-          type: string
-          format: uuid
-          example: 12345678-1234-5678-1234-56789abcdef4
-      - name: propertyName
-        in: path
-        description: the property to read from
-        required: true
-        schema:
-          type: string
-          example: "https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/temperature"
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Value'
-            application/octet-stream:
-              schema:
-                type: string
-                format: binary
-        default:
-          description: Error response
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-
   /devices/{id}/properties:
     put:
       tags:
@@ -211,7 +126,7 @@ paths:
                 $ref: '#/components/schemas/FailureResponse'
  
  ### NIPC Event APIs
-  /devices/{id}/events/{eventName}:
+  /devices/{id}/events:
     post:
       tags:
         - NIPC event APIs
@@ -229,7 +144,7 @@ paths:
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
       - name: eventName
-        in: path
+        in: query
         description: event that needs to be enabled
         required: true
         schema:
@@ -244,15 +159,14 @@ paths:
               schema:
                 type: string
                 format: uri
-                example: "/devices/{id}/events/{instanceId}"
+                example: "/devices/{id}/events?instanceId={instanceId}"
         default:
           description: Error response
           content:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
-  
-  /devices/{id}/events/{instanceId}:
+
     delete:
       tags:
         - NIPC event APIs
@@ -270,7 +184,7 @@ paths:
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
       - name: instanceId
-        in: path
+        in: query
         description: instance id of the event that needs to be disabled
         required: true
         schema:
@@ -286,47 +200,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
-                
-    get:
-      tags:
-        - NIPC event APIs
-      summary: Get status of an event on a specific device
-      description: |-
-        Get status of an event on a specific device or a groupd of devices. Success is event is active, failure if event not active.
-      operationId: GetEvent
-      parameters:
-      - name: id
-        in: path
-        description: device id or group id
-        required: true
-        schema:
-          type: string
-          format: uuid
-          example: 12345678-1234-5678-1234-56789abcdef4
-      - name: instanceId
-        in: path
-        description: instance id of the event that needs to be checked
-        required: true
-        schema:
-          type: string
-          format: uuid
-          example: 12345678-1234-5678-1234-56789abcdef4
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/Event' 
-        default:
-          description: Error response
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-
-  /devices/{id}/events:
+               
     get:
       tags:
         - NIPC event APIs
@@ -367,7 +241,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
 
-  /groups/{id}/events/{eventName}:
+  /groups/{id}/events:
     post:
       tags:
         - NIPC event APIs
@@ -385,7 +259,7 @@ paths:
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
       - name: eventName
-        in: path
+        in: query
         description: event that needs to be enabled
         required: true
         schema:
@@ -400,14 +274,13 @@ paths:
               schema:
                 type: string
                 format: uri
-                example: "/groups/{id}/events/{instanceId}"
+                example: "/groups/{id}/events?instanceId={instanceId}"
         default:
           description: Error response
           content:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
-  /groups/{id}/events/{instanceId}:
     delete:
       tags:
         - NIPC event APIs
@@ -425,7 +298,7 @@ paths:
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
       - name: instanceId
-        in: path
+        in: query
         description: instance id of the event that needs to be disabled
         required: true
         schema:
@@ -441,44 +314,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
-    get:
-      tags:
-        - NIPC event APIs
-      summary: Get status of an event on a group of devices
-      description: |-
-        Get status of an event on a group of devices. Success is event is active, failure if event not active.
-      operationId: GetGroupEvent
-      parameters:
-      - name: id
-        in: path
-        description: group id for which the event needs to be checked
-        required: true
-        schema:
-          type: string
-          format: uuid
-          example: 12345678-1234-5678-1234-56789abcdef4
-      - name: instanceId
-        in: path
-        description: instance id of the event that needs to be checked
-        required: true
-        schema:
-          type: string
-          format: uuid
-          example: 12345678-1234-5678-1234-56789abcdef4
-      responses:
-        '200':
-          description: Success, event is active
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Event'
-        default:
-          description: Error response
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/FailureResponse'
-  /groups/{id}/events:
     get:
       tags:
         - NIPC event APIs
@@ -520,7 +355,7 @@ paths:
                 $ref: '#/components/schemas/FailureResponse'
 
 ### NIPC action APIs
-  /devices/{id}/actions/{actionName}:
+  /devices/{id}/actions:
     post:
       tags:
         - NIPC action APIs
@@ -538,7 +373,7 @@ paths:
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
       - name: actionName
-        in: path
+        in: query
         description: action that needs to be performed
         required: true
         schema:
@@ -560,14 +395,13 @@ paths:
               schema:
                 type: string
                 format: uri
-                example: "/devices/{id}/actions/{instanceId}"
+                example: "/devices/{id}/actions?instanceId={instanceId}"
         default:
           description: Error response
           content:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/FailureResponse'
-  /devices/{id}/actions/{instanceId}:
     get:
       tags:
         - NIPC action APIs
@@ -585,7 +419,7 @@ paths:
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
       - name: instanceId
-        in: path
+        in: query
         description: instance id of the action that needs to be checked
         required: true
         schema:
@@ -649,7 +483,7 @@ paths:
   
     put:
       tags:
-        - NIPC action APIs with embedded protocol mapping
+        - NIPC management APIs
       summary: Update cached ServiceMap for a device.
       description: |-
         Update cached ServiceMap for a device. Full service discovery will be performed, unless specific services are described in the API body.
@@ -687,7 +521,7 @@ paths:
   
     delete:
       tags:
-        - NIPC action APIs with embedded protocol mapping
+        - NIPC management APIs
       summary: Disconnect a device 
       description: |-
         Disconnect a device.
@@ -718,7 +552,7 @@ paths:
                   
     get:
       tags:
-        - NIPC action APIs with embedded protocol mapping
+        - NIPC management APIs
       summary: Get connection state for a device
       description: |-
         Get connection status for a device. Success when device(s) is/are connected, includes service map for the device if available. Failure when a device is not connected
@@ -789,16 +623,21 @@ paths:
       description: |-
         Get all registered SDF model names.
       operationId: getSdfRefs
+      parameters:
+        - name: sdfName
+          in: query
+          description: sdfName can be a reference to an sdfThing or sdfObject
+          required: false
+          schema:
+            type: string
+            example: "https://example.com/heartrate#/sdfObject/healthsensor"
       responses:
         '200':
           description: Success
           content:
-            application/json:
+            application/sdf+json:
               schema:
-                type: array
-                items:
-                  allOf:
-                    - $ref: '#/components/schemas/SdfReference'
+                $ref: '#/components/schemas/SdfModel'
         default:
           description: Error response
           content:
@@ -806,9 +645,6 @@ paths:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse'
-
-
-  /registration/model/{sdfName}:
     put:
       tags:
         - NIPC registration APIs
@@ -818,7 +654,7 @@ paths:
       operationId: updateSdf
       parameters:
         - name: sdfName
-          in: path
+          in: query
           description: sdfName can be a reference to an sdfThing or sdfObject
           required: true
           schema:
@@ -877,38 +713,7 @@ paths:
                 allOf:
                   - $ref: '#/components/schemas/FailureResponse'
 
-    get:
-      tags:
-        - NIPC registration APIs
-      summary: get a registered sdfObject
-      description: |-
-        Get an sdfObject, including Properties, Events and actions
-      operationId: getSdfObject
-      parameters:
-        - name: sdfName
-          in: path
-          description: sdfObject name
-          required: true
-          schema:
-            type: string
-            example: "https://example.com/heartrate#/sdfObject/healthsensor"
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/SdfModel'
-        default:
-          description: Error response
-          content:
-            application/problem+json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/FailureResponse'
-
-  /registration/data-app/{dataAppId}:
+  /registration/data-app:
     post:
       tags:
         - NIPC registration APIs
@@ -918,7 +723,7 @@ paths:
       operationId: registerDataApp
       parameters:
         - name: dataAppId
-          in: path
+          in: query
           description: id of the data app that will be registered
           required: true
           schema:
@@ -1026,7 +831,7 @@ paths:
       operationId: GetDataApp
       parameters:
         - name: dataAppId
-          in: path
+          in: query
           description: id of the data app that will be updated
           required: true
           schema:

--- a/nipc-openapi/extensions/Extension-Bulk.yaml
+++ b/nipc-openapi/extensions/Extension-Bulk.yaml
@@ -220,7 +220,7 @@ components:
                 - /devices/{id}/properties?propertyName={propertyName}
                 - /devices/{id}/actions/?actionName={actionName}
                 - /extensions/{id}/properties/read/conditional?propertyName={propertyName}
-              example: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
+              example: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer%23/sdfThing/thermometer/sdfProperty/temperature
             data:
               type: object
               oneOf:
@@ -254,7 +254,7 @@ components:
                 - /devices/{id}/properties?propertyName={propertyName}
                 - /devices/{id}/actions/?actionName={actionName}
                 - /extensions/{id}/properties/read/conditional?propertyName={propertyName}
-              example: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
+              example: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer%23/sdfThing/thermometer/sdfProperty/temperature
             response:
               anyOf:
                 - $ref: '../NIPC.yaml#/components/schemas/Value'
@@ -267,13 +267,13 @@ components:
       value:
         operations:
           - method: GET
-            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer%23/sdfThing/thermometer/sdfProperty/temperature
           - method: PUT
-            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer%23/sdfThing/thermometer/sdfProperty/temperature
             data:
               value: dGVzdA==
           - method: POST
-            path: /extensions/12345678-1234-5678-1234-56789abcdef4/properties/read/conditional?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
+            path: /extensions/12345678-1234-5678-1234-56789abcdef4/properties/read/conditional?propertyName=https://example.com/thermometer%23/sdfThing/thermometer/sdfProperty/temperature
             data:
               value: dGVzdA==
               maxRepeat: 5
@@ -283,15 +283,15 @@ components:
       value:
         operations:
           - method: GET
-            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer%23/sdfThing/thermometer/sdfProperty/temperature
             response:
               value: dGVzdA==
           - method: PUT
-            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer%23/sdfThing/thermometer/sdfProperty/temperature
             response:
               status: 200
           - method: POST
-            path: /extensions/12345678-1234-5678-1234-56789abcdef4/properties/read/conditional?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
+            path: /extensions/12345678-1234-5678-1234-56789abcdef4/properties/read/conditional?propertyName=https://example.com/thermometer%23/sdfThing/thermometer/sdfProperty/temperature
             response:
               value: dGVzdA==
     errorBulkResponse:
@@ -299,21 +299,21 @@ components:
       value:
         operations:
           - method: GET
-            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer%23/sdfThing/thermometer/sdfProperty/temperature
             response:
               type: https://www.iana.org/assignments/http-problem-types#nipc-property-not-readable
               status: 400
               title: Property not readable
               detail: Property https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature is not readable
           - method: PUT
-            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer%23/sdfThing/thermometer/sdfProperty/temperature
             response:
               type: https://www.iana.org/assignments/http-problem-types#nipc-extension-operation-not-executed
               status: 400
               title: Operation not executed
               detail: Operation was not executed since the previous operation failed
           - method: POST
-            path: /extensions/12345678-1234-5678-1234-56789abcdef4/properties/read/conditional?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
+            path: /extensions/12345678-1234-5678-1234-56789abcdef4/properties/read/conditional?propertyName=https://example.com/thermometer%23/sdfThing/thermometer/sdfProperty/temperature
             response:
               type: https://www.iana.org/assignments/http-problem-types#nipc-extension-operation-not-executed
               status: 400

--- a/nipc-openapi/extensions/Extension-Bulk.yaml
+++ b/nipc-openapi/extensions/Extension-Bulk.yaml
@@ -217,10 +217,10 @@ components:
             path:
               type: string
               enum:
-                - /devices/{id}/properties/{propertyName}
-                - /devices/{id}/actions/{actionName}
-                - /extensions/{id}/properties/{propertyName}/read/conditional
-              example: /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
+                - /devices/{id}/properties?propertyName={propertyName}
+                - /devices/{id}/actions/?actionName={actionName}
+                - /extensions/{id}/properties/read/conditional?propertyName={propertyName}
+              example: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
             data:
               type: object
               oneOf:
@@ -251,10 +251,10 @@ components:
             path:
               type: string
               enum:
-                - /devices/{id}/properties/{propertyName}
-                - /devices/{id}/actions/{actionName}
-                - /extensions/{id}/properties/{propertyName}/read/conditional
-              example: /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
+                - /devices/{id}/properties?propertyName={propertyName}
+                - /devices/{id}/actions/?actionName={actionName}
+                - /extensions/{id}/properties/read/conditional?propertyName={propertyName}
+              example: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
             response:
               anyOf:
                 - $ref: '../NIPC.yaml#/components/schemas/Value'
@@ -267,13 +267,13 @@ components:
       value:
         operations:
           - method: GET
-            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
           - method: PUT
-            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
             data:
               value: dGVzdA==
           - method: POST
-            path: /extensions/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature/read/conditional
+            path: /extensions/12345678-1234-5678-1234-56789abcdef4/properties/read/conditional?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
             data:
               value: dGVzdA==
               maxRepeat: 5
@@ -283,15 +283,15 @@ components:
       value:
         operations:
           - method: GET
-            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
             response:
               value: dGVzdA==
           - method: PUT
-            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
             response:
               status: 200
           - method: POST
-            path: /extensions/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature/read/conditional
+            path: /extensions/12345678-1234-5678-1234-56789abcdef4/properties/read/conditional?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
             response:
               value: dGVzdA==
     errorBulkResponse:
@@ -299,21 +299,21 @@ components:
       value:
         operations:
           - method: GET
-            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
             response:
               type: https://www.iana.org/assignments/http-problem-types#nipc-property-not-readable
               status: 400
               title: Property not readable
               detail: Property https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature is not readable
           - method: PUT
-            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature
+            path: /devices/12345678-1234-5678-1234-56789abcdef4/properties?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
             response:
               type: https://www.iana.org/assignments/http-problem-types#nipc-extension-operation-not-executed
               status: 400
               title: Operation not executed
               detail: Operation was not executed since the previous operation failed
           - method: POST
-            path: /extensions/12345678-1234-5678-1234-56789abcdef4/properties/https%3A%2F%2Fexample.com%2Fthermometer%23%2FsdfThing%2Fthermometer%2FsdfProperty%2Ftemperature/read/conditional
+            path: /extensions/12345678-1234-5678-1234-56789abcdef4/properties/read/conditional?propertyName=https://example.com/thermometer#/sdfThing/thermometer/sdfProperty/temperature
             response:
               type: https://www.iana.org/assignments/http-problem-types#nipc-extension-operation-not-executed
               status: 400

--- a/nipc-openapi/extensions/Extension-ReadConditional.yaml
+++ b/nipc-openapi/extensions/Extension-ReadConditional.yaml
@@ -47,6 +47,7 @@ paths:
         in: query
         description: The SDF property name that needs to be read conditionally.
         required: true
+        allowReserved: true
         schema:
           type: string
           example: "#/sdfObject/thermostat/sdfProperty/temperature"
@@ -127,6 +128,7 @@ paths:
         in: query
         description: The SDF property name that needs to be read conditionally.
         required: true
+        allowReserved: true
         schema:
           type: string
           example: "#/sdfObject/thermostat/sdfProperty/temperature"
@@ -179,6 +181,7 @@ paths:
         in: query
         description: The SDF property name that needs to be read conditionally.
         required: true
+        allowReserved: true
         schema:
           type: string
           example: "#/sdfObject/thermostat/sdfProperty/temperature"

--- a/nipc-openapi/extensions/Extension-ReadConditional.yaml
+++ b/nipc-openapi/extensions/Extension-ReadConditional.yaml
@@ -27,7 +27,7 @@ tags:
 
 paths:
 ### Extensions
-  /extensions/{id}/properties/{propertyName}/read/conditional:
+  /extensions/{id}/properties/read/conditional:
     post:
       tags:
         - NIPC API extensions
@@ -44,7 +44,7 @@ paths:
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
       - name: propertyName
-        in: path
+        in: query
         description: The SDF property name that needs to be read conditionally.
         required: true
         schema:
@@ -124,7 +124,7 @@ paths:
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
       - name: propertyName
-        in: path
+        in: query
         description: The SDF property name that needs to be read conditionally.
         required: true
         schema:
@@ -159,7 +159,7 @@ paths:
               schema:
                 allOf:
                   - $ref: '../NIPC.yaml#/components/schemas/FailureResponse'
-  /extensions/{id}/properties/{propertyName}/read/conditional/status:
+  /extensions/{id}/properties/read/conditional/status:
     get:
       tags:
         - NIPC API extensions
@@ -176,7 +176,7 @@ paths:
           format: uuid
           example: 12345678-1234-5678-1234-56789abcdef4
       - name: propertyName
-        in: path
+        in: query
         description: The SDF property name that needs to be read conditionally.
         required: true
         schema:


### PR DESCRIPTION
Registration APIs: `/{sdfName}` → `?sdfName=...`
Event APIs: `/{eventName}`, `/{instanceId}` → `?eventName=...`, `?instanceId=...`
Action APIs: `/{actionName}`, `/{instanceId}` → `?actionName=...`, `?instanceId=...`
Property APIs: Use the existing multi-property read/write APIs.