### PR TITLE
Issues fixed for draft 14

### DIFF
--- a/draft-ietf-asdf-nipc.mkd
+++ b/draft-ietf-asdf-nipc.mkd
@@ -123,7 +123,7 @@ In order to perform NIPC operations on a device, 2 prerequisites must be fulfill
 - The device must be onboarded on the gateway. Onboarding declares a device instance to the gateway. This allows the NIPC Gateway to retrieve the device object, identified by an id referenced in the path of the NIPC API. The definition of the onboarding function is out of scope of this document, but can be provided by a provisioning interface such as {{!RFC7644}} leveraging {{!I-D.ietf-scim-device-model}}.
 - An interaction model for the class of devices must be registered with the gateway. This allows the gateway to understand how to interact with the device in a protocol-neutral way. The interaction model is provided to the gateway by means of an SDF model, described in {{!I-D.ietf-asdf-sdf}}.
 
-A non-IP gateway must provide at least following functions:
+A non-IP gateway provides following functions:
 
  - Authentication and authorization of application clients that
    will leverage the gateway API to communicate with Non-IP devices.


### PR DESCRIPTION
Provide reference to vendor-specific implementations #71 ([@Michael Richardson](mailto:mcr+ietf@sandelman.ca))
clarify scope section #73  ([@Michael Richardson](mailto:mcr+ietf@sandelman.ca))
NIPC GW definition #75  ([@Michael Richardson](mailto:mcr+ietf@sandelman.ca)))
Figure 2 #79 (@([@Michael Richardson](mailto:mcr+ietf@sandelman.ca))
Update references to draft-ietf-scim-device-model from SCIM #80 ([@Michael Richardson](mailto:mcr+ietf@sandelman.ca))
API authorization #81([@Michael Richardson](mailto:mcr+ietf@sandelman.ca))
JSON vs CBOR #82 ([@Michael Richardson](mailto:mcr+ietf@sandelman.ca))
.well_known #83 ([@Michael Richardson](mailto:mcr+ietf@sandelman.ca))
Device-ID #84 ([@Michael Richardson](mailto:mcr+ietf@sandelman.ca))
Async responses #85 ([@Michael Richardson](mailto:mcr+ietf@sandelman.ca))
SDF upper case #87 ([@Michael Richardson](mailto:mcr+ietf@sandelman.ca))
GET /{id}/property read-all #98 ([@Ari Keränen](mailto:ari.keranen=40ericsson.com@dmarc.ietf.org))
1.2 editorial #117 ([@Ari Keränen](mailto:ari.keranen=40ericsson.com@dmarc.ietf.org))
Define all acronyms and technical terms on first use #158 ([@Eliot Lear (elear)](mailto:elear@cisco.com))