### PR TITLE
Sync OpenAPI spec with draft and fix draft discrepancies

### DIFF
--- a/cddl/api/combined.cddl
+++ b/cddl/api/combined.cddl
@@ -277,12 +277,12 @@ zigbee-endpoint = {
 
 zigbee-cluster = {
   clusterID: uint,
-  ? properties: [* zigbee-property],
+  ? attributes: [* zigbee-attribute],
 }
 
-zigbee-property = {
+zigbee-attribute = {
   attributeID: uint,
-  propertyType: uint,
+  attributeType: uint,
 }
 
 zigbee-broadcast = {

--- a/cddl/api/group_action_status_response_array.cddl
+++ b/cddl/api/group_action_status_response_array.cddl
@@ -1,0 +1,17 @@
+; Group Action status response array and item shape
+
+GroupActionStatusResponseArray = [* GroupActionStatusResponse]
+
+GroupActionStatusResponse = (GroupActionSuccessResponse // GroupActionFailureResponse)
+
+GroupActionSuccessResponse = {
+  status: ActionStatus,
+  deviceId: text     ; UUID (as text)
+}
+
+ActionStatus = "IN_PROGRESS" / "COMPLETED"
+
+GroupActionFailureResponse = {
+  FailureResponse,
+  ? deviceId: text
+}

--- a/cddl/api/protocolinfo.cddl
+++ b/cddl/api/protocolinfo.cddl
@@ -57,12 +57,12 @@ zigbee-endpoint = {
 
 zigbee-cluster = {
   clusterID: uint,
-  ? properties: [* zigbee-property],
+  ? attributes: [* zigbee-attribute],
 }
 
-zigbee-property = {
+zigbee-attribute = {
   attributeID: uint,
-  propertyType: uint,
+  attributeType: uint,
 }
 
 zigbee-broadcast = {

--- a/cddl/examples/protocolinfo_zigbee_service_map.json
+++ b/cddl/examples/protocolinfo_zigbee_service_map.json
@@ -7,8 +7,8 @@
           "clusters": [
             {
               "clusterID": 0,
-              "properties": [
-                { "attributeID": 1, "propertyType": 32 }
+              "attributes": [
+                { "attributeID": 1, "attributeType": 32 }
               ]
             }
           ]

--- a/draft-ietf-asdf-nipc.mkd
+++ b/draft-ietf-asdf-nipc.mkd
@@ -883,9 +883,9 @@ Example of a response:
     "status": 200
   },
   {
-    "type": "https://www.iana.org/assignments/nipc-problem-types#invalid-property",
+    "type": "https://www.iana.org/assignments/nipc-problem-types#property-not-writable",
     "status": 400,
-    "title": "Invalid Property",
+    "title": "Property Not Writable",
     "detail": "Property https://example.com/heartrate#/sdfObject/thermostat/sdfProperty/temperature does not exist or is not writable"
   }
 ]
@@ -1238,6 +1238,76 @@ Example of a response:
 ~~~~~
 {:json #exactionstatusresp title="Example action status response" sourcecode-markers="true"}
 
+### Perform an action on a group of devices
+
+Method: `POST /groups/{id}/actions{?actionName}`
+
+Description: Perform an action on a group of devices
+
+Parameters:
+
+  - id: the ID of the group
+
+Query Parameters:
+
+  - actionName: the action to perform
+
+Request Body:
+
+The request body is optional and may contain a value. The media type of the value can be defined by the underlying protocol, for example it could be octet-stream for binary data.
+
+Response:
+
+Actions are performed asynchronously. A successful request returns HTTP status code 202 Accepted with a Location header pointing to the action instance for status checking, and a Retry-After header indicating the number of seconds the client should wait before polling.
+
+Example of a successful response:
+
+~~~~~
+HTTP/1.1 202 Accepted
+Location: /groups/0dc729d7-f6c3-491d-9b9d-e7176d2be243/actions?instanceId=02ee282c-8915-4b2e-bbd2-88966773134a
+Retry-After: 5
+~~~~~
+{: post="fold"}
+
+### Check group action status
+
+Method: `GET /groups/{id}/actions{?instanceId}`
+
+Description: Check the status of an action on a group of devices. Returns a per-device status array.
+
+Parameters:
+
+  - id: the ID of the group
+
+Query Parameters:
+
+  - instanceId: the instance ID of the action (obtained from the Location header)
+
+Response:
+
+MUST return 200 OK with an array of per-device action statuses. Each entry contains the action status and a deviceId. Entries for failed devices contain a problem detail with the deviceId.
+
+~~~~ cddl
+{::include-fold cddl/api/group_action_status_response_array.cddl}
+~~~~
+{:cddl sourcecode-markers="true" sourcecode-name="group_action_status_response_array.cddl"}
+
+Example of a response:
+
+~~~~~ json
+[
+  {
+    "status": "COMPLETED",
+    "deviceId": "1d3b2c36-8a65-45a6-87c1-bcdbe0a32e30"
+  },
+  {
+    "status": "IN_PROGRESS",
+    "deviceId": "d62c7fb2-a216-4811-a388-053b17fdbedc"
+  }
+]
+~~~~~
+{:json post="fold" #exgroupactionstatusresp title="Example group action status response" sourcecode-markers="true"}
+
 ## NIPC Trigger APIs
 
 Triggers APIs do not actually execute an operation on a device or group of devices, but install a trigger that registers an operation. When triggered the registered operation gets executed.
@@ -1357,7 +1427,7 @@ Example of a response:
 [
   {
     "instanceId": "02ee282c-8915-4b2e-bbd2-88966773134a",
-    "sdfName": "https://example.com/heartrate#/sdfObject/healthsensor",
+    "eventName": "https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected",
     "action": "/devices/3171ec43-42a5-4415-ab4b-afd0dfbe9615/actions?actionName=https%3A%2F%2Fexample.com%2FAlarmSystem%23%2FsdfObject%2Fbell%2FsdfAction%2Fring"
   }
 ]

--- a/nipc-openapi/NIPC.yaml
+++ b/nipc-openapi/NIPC.yaml
@@ -599,7 +599,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: The ID of the device. Group ID is not allowed.
+        description: The ID of the group of devices.
         required: true
         schema:
           type: string
@@ -647,11 +647,10 @@ paths:
           type: string
           format: uuid
           example: 1d3b2c36-8a65-45a6-87c1-bcdbe0a32e30
-      - name: sdfName
+      - name: eventName
         in: query
         description: |-
-          sdf affordance that will trigger this action, this can be 
-          either an event or an action
+          The SDF global name of the event that will trigger this action
         required: true
         allowReserved: true
         schema:
@@ -777,11 +776,10 @@ paths:
           type: string
           format: uuid
           example: 1d3b2c36-8a65-45a6-87c1-bcdbe0a32e30
-      - name: sdfName
+      - name: eventName
         in: query
         description: |-
-          sdf affordance that will trigger this action, this can be 
-          either an event or an action
+          The SDF global name of the event that will trigger this action
         required: true
         allowReserved: true
         schema:
@@ -879,12 +877,8 @@ paths:
           format: uuid
           example: 02ee282c-8915-4b2e-bbd2-88966773134a
       responses:
-        '200':
-          description: Success, trigger deleted
-          content:
-            application/nipc+json:
-              schema:
-                $ref: '#/components/schemas/GroupTriggerStatusResponseArray'
+        '204':
+          description: Success, no content
         default:
           description: Error response
           content:
@@ -1033,13 +1027,8 @@ paths:
             format: uuid
             example: 1d3b2c36-8a65-45a6-87c1-bcdbe0a32e30
       responses:
-        '200':
-          description: Success
-          content:
-            application/nipc+json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/Id'
+        '204':
+          description: Success, no content
         default:
           description: Error response
           content:
@@ -1110,8 +1099,8 @@ paths:
               $ref: '#/components/schemas/SdfModel'
         required: true
       responses:
-        '200':
-          description: Success
+        '201':
+          description: Created
           content:
             application/nipc+json:
               schema:
@@ -1130,15 +1119,18 @@ paths:
     get:
       tags:
         - NIPC registration APIs
-      summary: Get all registered SDF model names
+      summary: Get registered SDF models
       description: |-
-        Get all registered SDF model names.
+        Without sdfName, returns a list of all registered SDF model
+        references. With sdfName, returns the full SDF model for that
+        name.
       operationId: getSdfRefs
       parameters:
         - name: sdfName
           in: query
           description: |-
-            sdfName can be a reference to an sdfThing or sdfObject
+            sdfName can be a reference to an sdfThing or sdfObject.
+            If omitted, all registered model references are returned.
           required: false
           allowReserved: true
           schema:
@@ -1146,11 +1138,17 @@ paths:
             example: "https://example.com/heartrate#/sdfObject/healthsensor"
       responses:
         '200':
-          description: Success
+          description: |-
+            Without sdfName, returns a list of SDF model references.
+            With sdfName, returns the full SDF model.
           content:
             application/sdf+json:
               schema:
-                $ref: '#/components/schemas/SdfModel'
+                oneOf:
+                  - type: array
+                    items:
+                      $ref: '#/components/schemas/SdfReference'
+                  - $ref: '#/components/schemas/SdfModel'
         default:
           description: Error response
           content:
@@ -1254,8 +1252,8 @@ paths:
               $ref: '#/components/schemas/DataApp'
         required: true
       responses:
-        '200':
-          description: Success
+        '201':
+          description: Created
           content:
             application/nipc+json:
               schema:
@@ -1325,13 +1323,8 @@ paths:
             format: uuid
             example: 0927ce7c-b258-4bfa-a345-bcc9f74385b4
       responses:
-        '200':
-          description: Success
-          content:
-            application/nipc+json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DataApp'
+        '204':
+          description: Success, no content
         default:
           description: Error response
           content:
@@ -1555,6 +1548,15 @@ components:
         sdfName:
           type: string
           example: "https://example.com/heartrate#/sdfObject/healthsensor"
+
+ ## Event name reference for triggers
+    EventNameReference:
+      type: object
+      description: SDF global name of the event associated with a trigger
+      properties:
+        eventName:
+          type: string
+          example: "https://example.com/heartrate#/sdfObject/healthsensor/sdfEvent/fallDetected"
     
     SdfModel:
       allOf:
@@ -1713,6 +1715,7 @@ components:
             - https://www.iana.org/assignments/nipc-problem-types#extension-operation-not-executed
             - https://www.iana.org/assignments/nipc-problem-types#sdf-model-already-registered
             - https://www.iana.org/assignments/nipc-problem-types#sdf-model-in-use
+            - https://www.iana.org/assignments/nipc-problem-types#unsupported-uri-scheme
             - https://www.iana.org/assignments/nipc-problem-types#property-not-readable
             - https://www.iana.org/assignments/nipc-problem-types#property-read-failed
             - https://www.iana.org/assignments/nipc-problem-types#property-not-writable
@@ -1797,7 +1800,14 @@ components:
                 type: string
                 format: uuid
                 example: 0dc729d7-f6c3-491d-9b9d-e7176d2be243
-        - $ref: '#/components/schemas/FailureResponse'
+        - allOf:
+          - $ref: '#/components/schemas/FailureResponse'
+          - type: object
+            properties:
+              deviceId:
+                type: string
+                format: uuid
+                example: 9171ec16-e3c1-4ccf-ad23-b92a1a3f069d
 
     GroupEventStatusResponseArray:
       type: array
@@ -1806,11 +1816,14 @@ components:
     
     ActionResponse:
       required:
-        - action
+        - status
       type: object
       properties:
         status:
           type: string
+          enum:
+            - IN_PROGRESS
+            - COMPLETED
           example: COMPLETED
           description: |-
             Status of the action, can be IN_PROGRESS or COMPLETED
@@ -1836,9 +1849,9 @@ components:
     TriggerResponse:
       type: object
       allOf:
-        - $ref: '#/components/schemas/InstanceId'
-        - $ref: '#/components/schemas/SdfReference'
+        - $ref: '#/components/schemas/EventNameReference'
         - $ref: '#/components/schemas/Action'
+        - $ref: '#/components/schemas/InstanceId'
 
     TriggerStatusResponseArray:
       type: array
@@ -1854,7 +1867,7 @@ components:
               type: string
               format: uuid
               example: 0dc729d7-f6c3-491d-9b9d-e7176d2be243
-        - $ref: '#/components/schemas/SdfReference'
+        - $ref: '#/components/schemas/EventNameReference'
         - $ref: '#/components/schemas/Action'
 
     GroupTriggerStatusResponseArray:

--- a/nipc-openapi/protocolinfo/ProtocolInfo-Zigbee.yaml
+++ b/nipc-openapi/protocolinfo/ProtocolInfo-Zigbee.yaml
@@ -48,19 +48,19 @@ components:
           type: integer
           format: int32
           example: 0
-        properties:
+        attributes:
           type: array
           items:
-            $ref: '#/components/schemas/ProtocolInfo-Zigbee-Property'
+            $ref: '#/components/schemas/ProtocolInfo-Zigbee-Attribute'
 
-    ProtocolInfo-Zigbee-Property:
+    ProtocolInfo-Zigbee-Attribute:
       type: object
       properties:
         attributeID:
           type: integer
           format: int32
           example: 1
-        propertyType:
+        attributeType:
           type: integer
           format: int32
           example: 32


### PR DESCRIPTION
OpenAPI and CDDL:
- Fix HTTP status codes to match draft (201 for POST, 204 for DELETE)
- Rename trigger query param and response field from sdfName to eventName
- Add EventNameReference schema for trigger response composition
- Fix ActionResponse: required field and add status enum
- Add missing unsupported-uri-scheme error type
- Fix GET /registrations/models to support get-all vs get-by-name
- Add optional deviceId to group event failure responses

Draft and CDDL:
- Add group action POST and GET sections with CDDL definition
- Fix examples to use registered error types and correct field names
- Rename Zigbee property fields to `attribute` in CDDL and OpenAPI schemas